### PR TITLE
Simplification/cleanup + merging partial files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ target/
 .DS_Store
 data/
 temp/
+cfg/
 
 # Eclipse
 /.project

--- a/src/main/scala/nl/knaw/dans/api/sword2/MergeFiles.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/MergeFiles.scala
@@ -1,0 +1,38 @@
+package nl.knaw.dans.api.sword2
+
+import java.io._
+
+import org.apache.commons.io.IOUtils
+
+import scala.util.Try
+
+object MergeFiles {
+
+  def merge(destination: File, files: Seq[File]): Try[Unit] = Try {
+    var output: OutputStream = null
+    try {
+      output = createAppendableStream(destination)
+      files.foreach(appendFile(output))
+    } finally {
+      IOUtils.closeQuietly(output)
+    }
+  }
+
+  @throws(classOf[FileNotFoundException])
+  private def createAppendableStream(destination: File): BufferedOutputStream =
+    new BufferedOutputStream(new FileOutputStream(destination, true))
+
+  @throws(classOf[IOException])
+  private def appendFile(output: OutputStream)(file: File) {
+    var input: InputStream = null
+    try {
+      input = new BufferedInputStream(new FileInputStream(file))
+      IOUtils.copy(input, output)
+    } finally {
+      IOUtils.closeQuietly(input)
+    }
+  }
+
+}
+
+

--- a/src/main/scala/nl/knaw/dans/api/sword2/MergeFiles.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/MergeFiles.scala
@@ -34,5 +34,3 @@ object MergeFiles {
   }
 
 }
-
-

--- a/src/main/scala/nl/knaw/dans/api/sword2/MergeFiles.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/MergeFiles.scala
@@ -1,3 +1,18 @@
+/*******************************************************************************
+  * Copyright 2015 DANS - Data Archiving and Networked Services
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  ******************************************************************************/
 package nl.knaw.dans.api.sword2
 
 import java.io._


### PR DESCRIPTION
Single deposits are now handled by the same mechanism that handles continued deposits.
Continued deposits with (binary level) split files is also supported now.
