### PR TITLE
Changed the deposit ID generating code:

### DIFF
--- a/src/main/scala/nl/knaw/dans/api/sword2/CollectionDepositManagerImpl.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/CollectionDepositManagerImpl.scala
@@ -29,13 +29,9 @@ class CollectionDepositManagerImpl extends CollectionDepositManager {
   def createNew(collectionURI: String, deposit: Deposit, auth: AuthCredentials, config: SwordConfiguration): DepositReceipt = {
     Authentication.checkAuthentication(auth)
     val result = for {
-      - <- checkValidCollectionId(collectionURI)
-      timestamp <- SwordID.generate
+      _ <- checkValidCollectionId(collectionURI)
       maybeSlug = Option(deposit.getSlug)
-      id = maybeSlug match {
-              case Some(slug) => s"${auth.getUsername}-${slug}"
-              case None => s"${auth.getUsername}-${timestamp}"
-            }
+      id <- SwordID.generate(maybeSlug, auth.getUsername)
       _ = log.info(s"[$id] Created new deposit")
       _ <- setDepositStateToDraft(id, auth.getUsername)
       depositReceipt <- handleDeposit(deposit)(id)

--- a/src/main/scala/nl/knaw/dans/api/sword2/SwordID.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/SwordID.scala
@@ -20,7 +20,19 @@ import org.swordapp.server.SwordError
 import scala.util.{Failure, Success, Try}
 
 object SwordID {
-  def generate: Try[String] = synchronized {
+  def generate(maybeSlug: Option[String], user: String): Try[String] = Try {
+    val postfix = maybeSlug match {
+      case Some(slug) => slug
+      case None => generateTimeBasedPostfix.get
+    }
+    val prefix = SwordProps("auth.mode") match {
+      case "single" => ""
+      case _ => "$user-"
+    }
+    s"$prefix$postfix"
+  }
+
+  def generateTimeBasedPostfix = synchronized {
     try {
       val id: Long = System.currentTimeMillis
       Thread.sleep(2)
@@ -33,6 +45,6 @@ object SwordID {
   def extract(IRI: String): Try[String] = {
     val parts = IRI.split("/")
     if (parts.length < 1) Failure(new SwordError(404))
-    else Success(parts(parts.length - 1))
+    else Success(parts.last)
   }
 }


### PR DESCRIPTION
- The first part of the ID is now empty in single user setup (it doesn't make sense to put the same user
  ID there for every deposit)
- The second part contains the Slug if present, otherwise a Unix timestamp (this was merged before).

Moved the decision-making code to SwordID.
