### PR TITLE
Hashed password, issue #38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,10 @@
         <groupId>org.joda</groupId>
         <artifactId>joda-convert</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.scalatest</groupId>
+          <artifactId>scalatest_2.11</artifactId>
+      </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/src/main/scala/nl/knaw/dans/api/sword2/Authentication.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/Authentication.scala
@@ -16,6 +16,8 @@
 package nl.knaw.dans.api.sword2
 
 import java.util
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
 import javax.naming.{AuthenticationException, Context}
 import javax.naming.ldap.InitialLdapContext
 
@@ -28,6 +30,19 @@ import scala.util.{Failure, Success, Try}
 object Authentication {
   val log = LoggerFactory.getLogger(getClass)
 
+  def hash(password: String, userName: String): Array[Byte] = {
+    // Code deduced from the recommended https://crackstation.net/hashing-security.htm
+    // It states the salt should be some random number generated when choosing the password,
+    // stored together with the hashed password.
+    // As it is an internal user for an internal service we ignore the random salt requirement
+    // and apply the anti-pattern with the username as salt.
+    val salt = userName.getBytes()
+    val keyLength = 32
+    val iterations = 10
+    val spec = new PBEKeySpec(password.toCharArray, salt, iterations, keyLength * 8)
+    val skf = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")
+    skf.generateSecret(spec).getEncoded
+  }
 
   @throws(classOf[SwordError])
   @throws(classOf[SwordAuthException])
@@ -38,7 +53,10 @@ object Authentication {
     }
     log.debug(s"Checking credentials for user ${auth.getUsername} using auth.mode: ${SwordProps("auth.mode")}")
     SwordProps("auth.mode") match {
-      case "single" => if (!(auth.getUsername == SwordProps("auth.single.user")) || !(auth.getPassword == SwordProps("auth.single.password"))) throw new SwordAuthException
+      case "single" =>
+        val userNameMatches = auth.getUsername == SwordProps("auth.single.user")
+        val paswordMatches = hash(auth.getPassword, auth.getUsername) == SwordProps("auth.single.password").getBytes
+        if (! userNameMatches || ! paswordMatches) throw new SwordAuthException
       case "ldap" => if(!authenticateThroughLdap(auth.getUsername, auth.getPassword).get) throw new SwordAuthException
       case _ => throw new RuntimeException("Authentication not properly configured. Contact service admin")
     }

--- a/src/test/scala/nl/knaw/dans/api/sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl/knaw/dans/api/sword2/AuthenticationSpec.scala
@@ -1,19 +1,18 @@
-/*******************************************************************************
-  * Copyright 2015 DANS - Data Archiving and Networked Services
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  *   http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  ******************************************************************************/
-
+/**
+ * Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.api.sword2
 
 import nl.knaw.dans.api.sword2.Authentication.hash
@@ -21,18 +20,18 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class AuthenticationSpec extends FlatSpec with Matchers {
 
-  val command = "echo -n SomePassword | openssl sha1 -hmac someUserNameAsSalt -binary | base64"
+  val command = "echo -n 'SomePassword' | openssl sha1 -hmac 'someUserNameAsSalt' -binary | base64"
   val output = "WjYViDQOdGR8V1kkTs900ZfoLXU="
 
-  "hash" should s"return same as '$command'" in {
+  "hash" should s"return same as: $command" in {
     hash("SomePassword", "someUserNameAsSalt") shouldBe output
   }
 
-  it should "return something else than '$command'" in {
+  it should s"return something else than: $command" in {
     hash("somePassword", "someUserNameAsSalt") should not be output
   }
 
-  it should s"not return same as '$command'" in {
+  it should s"not return same as: $command" in {
     hash("SomePassword", "SomeUserNameAsSalt") should not be output
   }
 }

--- a/src/test/scala/nl/knaw/dans/api/sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl/knaw/dans/api/sword2/AuthenticationSpec.scala
@@ -1,0 +1,35 @@
+/*******************************************************************************
+  * Copyright 2015 DANS - Data Archiving and Networked Services
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  ******************************************************************************/
+
+package nl.knaw.dans.api.sword2
+
+import nl.knaw.dans.api.sword2.Authentication.hash
+import org.scalatest.{FlatSpec, Matchers}
+
+class AuthenticationSpec extends FlatSpec with Matchers {
+
+  // TODO somehow match the implemetation of 'hash' with some command line
+
+  "hash" should "return same as 'echo -n SomePassword | openssl sha1 -hmac someUserNameAsSalt'" in {
+    hash("SomePassword","someUserNameAsSalt") shouldBe "5a361588340e74647c5759244ecf74d197e82d75"
+  }
+
+  "hash" should "return same as 'echo -n SomePassword | openssl sha1 -hmac someUserNameAsSalt -binary | base64'" in {
+    new sun.misc.BASE64Encoder().encode(
+      hash("SomePassword","someUserNameAsSalt")
+    ) shouldBe "WjYViDQOdGR8V1kkTs900ZfoLXU="
+  }
+}

--- a/src/test/scala/nl/knaw/dans/api/sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl/knaw/dans/api/sword2/AuthenticationSpec.scala
@@ -21,15 +21,18 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class AuthenticationSpec extends FlatSpec with Matchers {
 
-  // TODO somehow match the implemetation of 'hash' with some command line
+  val command = "echo -n SomePassword | openssl sha1 -hmac someUserNameAsSalt -binary | base64"
+  val output = "WjYViDQOdGR8V1kkTs900ZfoLXU="
 
-  "hash" should "return same as 'echo -n SomePassword | openssl sha1 -hmac someUserNameAsSalt'" in {
-    hash("SomePassword","someUserNameAsSalt") shouldBe "5a361588340e74647c5759244ecf74d197e82d75"
+  "hash" should s"return same as '$command'" in {
+    hash("SomePassword", "someUserNameAsSalt") shouldBe output
   }
 
-  "hash" should "return same as 'echo -n SomePassword | openssl sha1 -hmac someUserNameAsSalt -binary | base64'" in {
-    new sun.misc.BASE64Encoder().encode(
-      hash("SomePassword","someUserNameAsSalt")
-    ) shouldBe "WjYViDQOdGR8V1kkTs900ZfoLXU="
+  it should "return something else than '$command'" in {
+    hash("somePassword", "someUserNameAsSalt") should not be output
+  }
+
+  it should s"not return same as '$command'" in {
+    hash("SomePassword", "SomeUserNameAsSalt") should not be output
   }
 }


### PR DESCRIPTION
@DANS-KNAW/easy 
The code of the first commit in this pull request is partly advised, partly commented as anti-pattern in the [documentation](https://crackstation.net/hashing-security.htm) recommended in the issue. As we have just one internal account for an internal service the implementation seems good enough.

However, I could not figure out a corresponding command line, so the final implementation performs another calculation, the corresponding command line is documented in the unit test.
