### PR TITLE
Fixed two bugs

### DIFF
--- a/src/main/scala/nl/knaw/dans/api/sword2/CollectionDepositManagerImpl.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/CollectionDepositManagerImpl.scala
@@ -43,12 +43,12 @@ class CollectionDepositManagerImpl extends CollectionDepositManager {
     if(iri != SwordProps("collection.iri")) throw new SwordError("http://purl.org/net/sword/error/MethodNotAllowed", 405, s"Not a valid collection IRI: $iri")
   }
 
-  private def setDepositStateToDraft(id: String, userId: String): Try[Unit] = Try {
+  private def setDepositStateToDraft(id: String, userId: String): Try[Unit] =
     DepositProperties.set(
       id = id,
       stateLabel = "DRAFT",
       stateDescription = "Deposit is open for additional data",
       userId = Some(userId),
       lookInTempFirst = true)
-  }
+
 }

--- a/src/main/scala/nl/knaw/dans/api/sword2/DepositProperties.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/DepositProperties.scala
@@ -65,8 +65,8 @@ object DepositProperties {
   private def readProperties(f: File) = {
     val ps = new PropertiesConfiguration()
     ps.setDelimiterParsingDisabled(true)
-    ps.load(f)
-
+    if(f.exists) ps.load(f)
+    ps.setFile(f)
     ps
   }
 }


### PR DESCRIPTION
#### When applied it will
- Fix the regression bug introduced by 50c7b5db9deb6306e9bbf4448a6521f194fad690. The problem was that  `deposit.properties` initially does not exist, which causes the deposit to fail when the code tries to load it.
- Fix a nested Try construct which caused above error not to be reported back to the client. (A `Failure` object was wrapped inside a `Success`.) 
#### Where should the reviewer @DANS-KNAW/easy start?

`DepositProperties.scala`
#### How should this be manually tested?

In `easy-dtap`:

```
./deploy-role easy_sword2
```

In `easy-sword2/src/test/resources`:

```
./send-simple.sh simple/example-bag.zip http://deasy.dans.knaw.nl/sword2/collection/1
```

If you want to check that an exception in `DepositProperties.set` does show up in the response sent to the client, you could rebuild the project with a hardcode `throw new RuntimeException("foo")` in that method and perform the test again.
#### related pull requests on github

none
