### PR TITLE
Attempt to fix EASY-1085. The virus scanner sometimes gets a

### DIFF
--- a/src/main/scala/nl/knaw/dans/api/sword2/DepositHandler.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/DepositHandler.scala
@@ -215,9 +215,9 @@ object DepositHandler {
       log.debug("Moving bag to permanent storage")
       val tempDir = new File(SwordProps("tempdir"), id)
       val storageDir = new File(SwordProps("deposits.rootdir"), id)
+      if(isOnPosixFileSystem(tempDir))
+        Files.walkFileTree(tempDir.toPath, MakeAllGroupWritable(SwordProps("deposits.permissions")))
       if(!tempDir.renameTo(storageDir)) throw new SwordError(s"Cannot move $tempDir to $storageDir")
-      if(isOnPosixFileSystem(storageDir))
-        Files.walkFileTree(storageDir.toPath, MakeAllGroupWritable(SwordProps("deposits.permissions")))
       storageDir
     }.recover { case e => throw new SwordError("Failed to move dataset to storage", e) }
 


### PR DESCRIPTION
Fixes EASY-1085 (hopefully)
#### When applied it will
- make sure that `easy-ingest-dispatcher` no longer fails on the virus scan step because of a "permission denied" condition.
#### Where should the reviewer @DANS-KNAW/easy start?

Only a couple of lines changed.
#### How should this be manually tested?
- Install clamav on `deasy` (no longer done automatically)
- Make sure you configure `easy-ingest-dispatcher` to use clamscan: `/usr/bin/clamscan -r -v`. See the dispatcher's  `application.properties` file.
- User `easy-sword2-dans-examples` to do a SWORD2 deposit, while tailing the `easy-ingest-dispachter`'s log file.
