### PR TITLE
Improve client's error messages

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -13,3 +13,4 @@ auth.single.password={{ easy_sword2_auth_single_password }}
 url-pattern=^https?://.*
 bag-store.base-url={{ easy_bag_store_baseuri }}
 bag-store.base-dir={{ easy_bag_store_basedir }}
+support.mailaddress={{ easy_sword2_support_mail_address }}

--- a/src/main/scala/nl/knaw/dans/api/sword2/DepositHandler.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/DepositHandler.scala
@@ -94,11 +94,8 @@ object DepositHandler {
       case InvalidDepositException(_, msg, cause) =>
         log.error(s"[$id] Invalid deposit", cause)
         DepositProperties.set(id, "INVALID", msg, lookInTempFirst = true)
-      case FailedDepositException(_, msg, cause) =>
-        log.error(s"[$id] Failed deposit", cause)
-        DepositProperties.set(id, "FAILED", genericErrorMessage, lookInTempFirst = true)
-      case NonFatal(e)  =>
-        log.error(s"[$id] Unexpected failure in deposit", e)
+      case NonFatal(e) =>
+        log.error(s"[$id] Internal failure in deposit", e)
         DepositProperties.set(id, "FAILED", genericErrorMessage, lookInTempFirst = true)
     }
   }
@@ -142,8 +139,8 @@ object DepositHandler {
   }
 
   def checkBagStoreBaseDir()(implicit id: String, baseDir: File): Try[Unit] = {
-    if (!baseDir.exists) Failure(FailedDepositException(id, s"Bag store base directory ${baseDir.getAbsolutePath} doesn't exist"))
-    else if (!baseDir.canRead) Failure(FailedDepositException(id, s"Bag store base directory ${baseDir.getAbsolutePath} is not readable"))
+    if (!baseDir.exists) Failure(new IOException(s"Bag store base directory ${baseDir.getAbsolutePath} doesn't exist"))
+    else if (!baseDir.canRead) Failure(new IOException(s"Bag store base directory ${baseDir.getAbsolutePath} is not readable"))
     else Success(())
   }
 

--- a/src/main/scala/nl/knaw/dans/api/sword2/DepositHandler.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/DepositHandler.scala
@@ -16,32 +16,31 @@
 package nl.knaw.dans.api.sword2
 
 import java.io.{File, IOException}
-import java.nio.file.attribute.{BasicFileAttributes, PosixFilePermissions}
-import java.nio.file._
-import java.util.Collections
 import java.net.{MalformedURLException, URI, URL, UnknownHostException}
+import java.nio.file._
+import java.nio.file.attribute.{BasicFileAttributes, PosixFilePermissions}
+import java.util.Collections
 import java.util.regex.Pattern
 
 import gov.loc.repository.bagit.FetchTxt.FilenameSizeUrl
-import gov.loc.repository.bagit.{Bag, BagFactory, FetchTxt}
 import gov.loc.repository.bagit.utilities.SimpleResult
 import gov.loc.repository.bagit.verify.CompleteVerifier
+import gov.loc.repository.bagit.{Bag, BagFactory, FetchTxt}
 import net.lingala.zip4j.core.ZipFile
+import nl.knaw.dans.lib.error.{CompositeException, TraversableTryExtensions}
 import org.apache.abdera.i18n.iri.IRI
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.io.FileUtils._
+import org.joda.time.{DateTime, DateTimeZone}
 import org.slf4j.LoggerFactory
 import org.swordapp.server.{Deposit, DepositReceipt, SwordError}
+import resource.Using
 import rx.lang.scala.schedulers.NewThreadScheduler
 import rx.lang.scala.subjects.PublishSubject
 
-import scala.util.{Failure, Success, Try}
 import scala.collection.JavaConverters._
-import resource.Using
-import nl.knaw.dans.lib.error.{CompositeException, TraversableTryExtensions}
-import org.joda.time.{DateTime, DateTimeZone}
-
 import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
 
 object DepositHandler {
   val log = LoggerFactory.getLogger(getClass)

--- a/src/main/scala/nl/knaw/dans/api/sword2/DepositProperties.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/DepositProperties.scala
@@ -37,7 +37,7 @@ object DepositProperties {
         |$stateDescription
         |${if(throwable != null) throwable.getMessage else ""}
       """.stripMargin.trim)
-    if(userId.nonEmpty) props.setProperty("depositor.userId", userId.get)
+    userId.foreach(uid => props.setProperty("depositor.userId", uid))
     props.save()
   }
 

--- a/src/main/scala/nl/knaw/dans/api/sword2/package.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/package.scala
@@ -32,7 +32,6 @@ package object sword2 {
   var homeDir: File = null
 
   case class InvalidDepositException(id: String, msg: String, cause: Throwable = null) extends Exception(msg, cause)
-  case class FailedDepositException(id: String, msg: String, cause: Throwable = null) extends Exception(msg, cause)
 
   implicit class FileOps(val thisFile: File) extends AnyVal {
 


### PR DESCRIPTION
fixes EASY-1135
#### When applied it will
- [x] give clear error messages to the client when its input is invalid
- [x] give a generic error message when an internal error occurs (server-side)
- [x] take proper care of `CompositeException`s
- [x] remove the `FailedDepositException`
#### Where should the reviewer @DANS-KNAW/easy start?

`DepositHandler.scala`
#### How should this be manually tested?
- [x] test the whole stuff

Give as many invalid inputs as you can possible think of and see what the application gives you back! Think 'invalid URLs', 'not allowed URLs', 'invalid checksums', 'fetch items refer to paths that already exist (same file)', 'fetch item overrides file that does already exist (other file)'.

You can use [easy-sword2-dans-examples](https://github.com/DANS-KNAW/easy-sword2-dans-examples) to submit your test bags!
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy-dtap | [PR#46](https://github.com/DANS-KNAW/easy-dtap/pull/46) |
