### PR TITLE
FAILED deposit if properties missing in deposit.properties

### DIFF
--- a/src/main/scala/nl/knaw/dans/api/sword2/DepositProperties.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/DepositProperties.scala
@@ -51,7 +51,15 @@ object DepositProperties {
     val s = readProperties(f)
     log.debug(s"[$id] Trying to retrieve state from $f")
     if(!f.exists()) throw new IOException(s"$f does not exist")
-    State(s.getString("state.label"), s.getString("state.description"), new DateTime(s.getFile.lastModified()).withZone(DateTimeZone.UTC).toString)
+    val state = Option(s.getString("state.label")).getOrElse("")
+    val userId = Option(s.getString("depositor.userId")).getOrElse("")
+    if(state.isEmpty || userId.isEmpty) {
+      if (state.isEmpty) log.error(s"[$id] State not present in $f")
+      if (userId.isEmpty) log.error(s"[$id] User ID not present in $f")
+      State("FAILED", "There occured unexpected failure in deposit", new DateTime(s.getFile.lastModified()).withZone(DateTimeZone.UTC).toString)
+    }
+    else
+      State(state, s.getString("state.description"), new DateTime(s.getFile.lastModified()).withZone(DateTimeZone.UTC).toString)
   }
 
   private def stackTraceToString(t: Throwable): String = {


### PR DESCRIPTION
fixes EASY-1142

#### When applied
* When client asks deposit status, it returns statement of FAILED deposit, when `state` or `userId` is not present in `deposit.properties`
* logs an error about the missing property (properties)

#### How should this be manually tested?
```
Start easy-dtap
Upload en unzip het bijgevoegde zip-bestand corrupt-deposit.zip naar /data/easy-sword2/deposits/. Dit creëert een sub-directory user001-1477380082000
Doe chown -R tomcat:deposits op de directory user001-1477380082000
Doe chmod -R 770 op de directory user001-1477380082000
Vraag het statement via http://deasy.dans.knaw.nl/sword2/statement/user001-1477380082000 en de (default) credentials user001/user001. Hiervoor kun je curl direct aanroepen of het wrapper-scriptje get.sh in src/test/resources/input gebruiken.

```

#### Further
Now there is no check whether state or userId contain valid values. Is there an enumeration of states? Should we check the userId against...?