### PR TITLE
Fixed authentication/authorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
             <artifactId>scalatest_2.11</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scalamock</groupId>
+            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.jsuereth</groupId>
             <artifactId>scala-arm_2.11</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.35</version>
+        <version>1.38</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-sword2</artifactId>

--- a/src/main/scala/nl/knaw/dans/api/sword2/ServiceDocumentManagerImpl.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/ServiceDocumentManagerImpl.scala
@@ -30,6 +30,7 @@ class ServiceDocumentManagerImpl extends ServiceDocumentManager {
     log.info("Service document retrieved by {}",
       if (authCredentials.getUsername.isEmpty) "Anonymous user"
       else authCredentials.getUsername)
+    if (Authentication.checkAuthentication(authCredentials).isFailure) throw new SwordAuthException()
     val sdoc: ServiceDocument = new ServiceDocument
     val sw: SwordWorkspace = new SwordWorkspace
     sw.setTitle("EASY SWORD2 Deposit Service")

--- a/src/main/scala/nl/knaw/dans/api/sword2/ServiceDocumentManagerImpl.scala
+++ b/src/main/scala/nl/knaw/dans/api/sword2/ServiceDocumentManagerImpl.scala
@@ -30,6 +30,7 @@ class ServiceDocumentManagerImpl extends ServiceDocumentManager {
     log.info("Service document retrieved by {}",
       if (authCredentials.getUsername.isEmpty) "Anonymous user"
       else authCredentials.getUsername)
+    if (Authentication.checkAuthentication(authCredentials).isFailure) throw SwordAuthException
     val sdoc: ServiceDocument = new ServiceDocument
     val sw: SwordWorkspace = new SwordWorkspace
     sw.setTitle("EASY SWORD2 Deposit Service")

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="nl.knaw.dans.easy" level="${LOG_LEVEL:-off}" />
+    <logger name="nl.knaw.dans.api" level="${LOG_LEVEL:-off}" />
     <logger name="org.scalatest" level="info" />
 
 </configuration>


### PR DESCRIPTION
Fixes EASY-1157

#### When applied it will
* Make sure authentication/authorization is done before every request

#### Where should the reviewer @DANS-KNAW/easy start?
The `Authentication` object

#### How should this be manually tested?
Run the `easy-sword2-dans-examples` and provide a wrong password or user/password for an account that is not SWORD enabled and check that the request receives a 403
