### PR TITLE
NO JIRA ISSUE: Edit-IRI returns 404 for invalid, but existing deposit

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -63,6 +63,8 @@ class DepositProperties(depositId: String, depositorId: Option[String] = None)(i
     properties.save()
   }
 
+  def exists: Boolean = properties.getFile.exists
+
   def setState(state: State, descr: String): Try[DepositProperties] = Try {
     properties.setProperty("state.label", state)
     properties.setProperty("state.description", descr)


### PR DESCRIPTION
The Edit-IRI returned a 404 when it was invalid, because the code only looked in the inbox
to see if it could find the deposit. When a deposit is invalid, however, it is never moved
to the inbox, but instead left in the temp directory. Now the client uses the DepositProperties
object, which looks in both places.

