### PR TITLE
NO JIRA ISSUE: pospone deleting zips until after validation

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -117,10 +117,11 @@ object DepositHandler {
 
   private def removeZipFiles(bagDir: File): Try[Unit] = Try {
     log.debug("Removing zip files")
-    bagDir.listFiles().toList.filter(f => isPartOfDeposit(f) && f.isFile).foreach {
-      f =>
-        log.debug(s"Removing $f")
-        deleteQuietly(f)
+    for (file <- bagDir.listFiles().toList
+         if isPartOfDeposit(file)
+         if file.isFile) {
+      log.debug(s"Removing $file")
+      deleteQuietly(file)
     }
   }
 


### PR DESCRIPTION
The zip files received from the client where deleted as soon as the combined
zip was unpacked. The disadvantage of this was that is was then impossible to
examine the zip file if the bag was found to be invalid. Examining the zip file
could be useful to trace back the problem to the client (or determine that the
the error was caused on the server).

I have now moved the step to delete the zip files to after the validation. It will
only be done if the bag is found to be VALID.

