### PR TITLE
EASY-1254

### DIFF
--- a/src/main/assembly/dist/bin/easy-sword2-initd.sh
+++ b/src/main/assembly/dist/bin/easy-sword2-initd.sh
@@ -27,6 +27,8 @@ WAIT_TIME=60
 jsvc_exec()
 {
     cd ${APPHOME}
+    # Set LC_ALL to a locale with UTF-8 to make sure non-ASCII file names are written correctly to the file system (see: EASY-1254).
+    LC_ALL=en_US.UTF-8 \
     ${EXEC} -home ${JAVA_HOME} -cp ${CLASSPATH} -user ${USER} -outfile ${OUTFILE} -errfile ${ERRFILE} -pidfile ${PID} -wait ${WAIT_TIME} \
           -Dapp.home=${APPHOME} -Dconfig.file=${APPHOME}/cfg/application.conf \
           -Dlogback.configurationFile=${APPHOME}/cfg/logback-service.xml $1 ${CLASS} ${ARGS}

--- a/src/main/assembly/dist/bin/easy-sword2-service-start
+++ b/src/main/assembly/dist/bin/easy-sword2-service-start
@@ -3,6 +3,8 @@
 BINPATH=`command readlink -f $0 2> /dev/null || command grealpath $0 2> /dev/null`
 APPHOME=`dirname \`dirname $BINPATH \``
 
+# Set LC_ALL to a locale with UTF-8 to make sure non-ASCII file names are written correctly to the file system (see: EASY-1254).
+LC_ALL=en_US.UTF-8 \
 java -Dlogback.configurationFile=$APPHOME/cfg/logback-service.xml \
      -Dapp.home=$APPHOME \
-     -cp $APPHOME/bin/easy-bag-store.jar nl.knaw.dans.easy.sword2.Sword2Service
+     -cp $APPHOME/bin/easy-sword2.jar nl.knaw.dans.easy.sword2.Sword2Service

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.sword2
 
 import java.io.{File, IOException}
 import java.net.{MalformedURLException, URL, UnknownHostException}
+import java.nio.charset.StandardCharsets
 import java.nio.file._
 import java.nio.file.attribute.{BasicFileAttributes, PosixFilePermissions}
 import java.util.regex.Pattern
@@ -127,9 +128,9 @@ object DepositHandler {
 
   private def extractBag(mimeType: String)(implicit settings: Settings, id: String): Try[File] = {
     def extract(file: File, outputPath: String): Unit = {
-      val zip = new ZipFile(file.getPath)
-      zip.setFileNameCharset("UTF-8")
-      zip.extractAll(outputPath)
+      new ZipFile(file.getPath) {
+        setFileNameCharset(StandardCharsets.UTF_8.name)
+      }.extractAll(outputPath)
     }
 
     def getSequenceNumber(f: File): Int = {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -126,7 +126,11 @@ object DepositHandler {
   }
 
   private def extractBag(mimeType: String)(implicit settings: Settings, id: String): Try[File] = {
-    def extract(file: File, outputPath: String): Unit = new ZipFile(file.getPath).extractAll(outputPath)
+    def extract(file: File, outputPath: String): Unit = {
+      val zip = new ZipFile(file.getPath)
+      zip.setFileNameCharset("UTF-8")
+      zip.extractAll(outputPath)
+    }
 
     def getSequenceNumber(f: File): Int = {
       try {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ServiceStarter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ServiceStarter.scala
@@ -25,6 +25,7 @@ class ServiceStarter extends Daemon {
   def init(ctx: DaemonContext) = {
     log = LoggerFactory.getLogger(getClass)
     log.info("Initializing service...")
+    log.info(s"LC_ALL = ${System.getenv("LC_ALL")}")
     service = new Sword2Service
     log.info("Service initialized.")
   }


### PR DESCRIPTION
Added locale config to service start-up scripts, so that files are read and
written with UTF-8 encoded file names

fixes EASY-1254