### PR TITLE
Disk space

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,6 +1,8 @@
 deposits.rootdir={{ easy_sword2_deposits_root_dir }}
 deposits.permissions={{ easy_sword2_deposits_permissions }}
 tempdir={{ easy_sword2_temp_dir }}
+# Require at least some 2 G  spare disk space
+tempdir.margin-available-diskspace-mb=2000
 base-url={{ easy_sword2_base_url }}
 collection.path={{ easy_sword2_collection_path }}
 auth.mode={{ easy_sword2_auth_mode }}
@@ -17,3 +19,4 @@ bag-store.base-dir=
 support.mailaddress={{ easy_sword2_support_mail_address }}
 daemon.http.port={{ easy_sword2_http_port }}
 daemon.ajp.port={{ easy_sword2_ajp_port }}
+

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationSettings.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationSettings.scala
@@ -55,4 +55,5 @@ trait ApplicationSettings {
     bagStoreSettings = Some(BagStoreSettings(bagStoreBaseDir, bagStoreBaseUri))
   }
   val supportMailAddress = properties.getString("support.mailaddress")
+  val marginDiskSpace: Long = properties.getLong("tempdir.margin-available-diskspace-mb") * 1024 * 1024
 }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/MergeFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/MergeFiles.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.sword2
 
 import java.io._
 
-import org.apache.commons.io.IOUtils
+import org.apache.commons.io.{ FileUtils, IOUtils }
 
 import scala.util.Try
 
@@ -29,6 +29,7 @@ object MergeFiles {
       output = createAppendableStream(destination)
       files.foreach(appendFile(output))
     } finally {
+      files.foreach(FileUtils.deleteQuietly)
       IOUtils.closeQuietly(output)
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/Sword2Service.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Sword2Service.scala
@@ -30,7 +30,7 @@ class Sword2Service extends ApplicationSettings with DebugEnhancedLogging  {
   val context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
   val settings = Settings(
     depositRootDir, depositPermissions, tempDir, baseUrl, collectionPath, auth, urlPattern,
-    bagStoreSettings, supportMailAddress)
+    bagStoreSettings, supportMailAddress, marginDiskSpace)
   context.setAttribute(servlets.EASY_SWORD2_SETTINGS_ATTRIBUTE_KEY, settings)
 
   /*

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -39,11 +39,13 @@ package object sword2 {
                        auth: AuthenticationSettings,
                        urlPattern: Pattern,
                        bagStoreSettings: Option[BagStoreSettings],
-                       supportMailAddress: String)
+                       supportMailAddress: String,
+                       marginDiskSpace: Long)
 
   case class BagStoreSettings(baseDir: String, baseUrl: String)
 
   case class InvalidDepositException(id: String, msg: String, cause: Throwable = null) extends Exception(msg, cause)
+  case class RejectedDepositException(id: String, msg: String, cause: Throwable = null) extends Exception(msg, cause)
 
   implicit class FileOps(val thisFile: File) extends AnyVal {
 

--- a/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
@@ -40,7 +40,8 @@ class AuthenticationSpec extends FlatSpec with Matchers with MockFactory with On
     auth = LdapAuthSettings(new URI("ldap://localhost"), "ou=easy,dc=dans,dc=knaw,dc=nl", "enabled", "true"),
     urlPattern = Pattern.compile("dummy"),
     bagStoreSettings = None,
-    supportMailAddress = "dummy")
+    supportMailAddress = "dummy",
+    marginDiskSpace = 0)
 
   private val ldapContext = mock[LdapContext]
   private val attributes = mock[Attributes]


### PR DESCRIPTION
NO JIRA ISSUE.

Quick fix. This adds checks to see if there is enough disk space to go ahead before concatenating partial deposits and before unzipping the deposit. If there isn't the deposit is rejected, so that smaller deposits can continue to be processed.

Warning: the code isn't pretty, but as I work on this code I realize it needs to be thoroughly cleaned up anyway. 