### PR TITLE
EASY-1252 - Sword2 deposits moeten DOI kunnen aanmaken en terugleveren

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>easy-sword2-lib</artifactId>
-            <!-- <version>1.0-beta-2</version> -->
-            <version>1.x-SNAPSHOT</version>
+            <version>1.0-beta-3</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>easy-sword2-lib</artifactId>
-            <version>1.0-beta-2</version>
+            <!-- <version>1.0-beta-2</version> -->
+            <version>1.x-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -104,6 +104,10 @@ class DepositProperties(depositId: String, depositorId: Option[String] = None)(i
       .getOrElse(Failure(new IllegalStateException("Deposit without depositor")))
   }
 
+  def getDoi: Option[String] = {
+    Option(properties.getProperty("identifier.doi"))
+      .map(_.toString)
+  }
 
   /**
    * Returns the last modified timestamp when the properties were loaded.

--- a/src/main/scala/nl.knaw.dans.easy.sword2/StatementManagerImpl.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/StatementManagerImpl.scala
@@ -40,11 +40,17 @@ class StatementManagerImpl extends StatementManager with DebugEnhancedLogging {
       _ = debug(s"State = $state")
       stateDesc <- props.getStateDescription
       _ = debug(s"State desc = $stateDesc")
+      optDoi = props.getDoi
       statement <- Try {
         val statement = new AtomStatement(iri, "DANS-EASY", s"Deposit $id", props.getLastModifiedTimestamp.get.toString)
         statement.addState(state.toString, stateDesc)
         val archivalResource = new ResourcePart(new URI(s"urn:uuid:$id").toASCIIString)
         archivalResource.setMediaType("multipart/related")
+
+        optDoi.foreach(doi => {
+          archivalResource.addSelfLink(new URI(s"http://doi.org/$doi").toASCIIString)
+        })
+
         statement.addResource(archivalResource)
         statement
       }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/StatementManagerImpl.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/StatementManagerImpl.scala
@@ -48,7 +48,7 @@ class StatementManagerImpl extends StatementManager with DebugEnhancedLogging {
         archivalResource.setMediaType("multipart/related")
 
         optDoi.foreach(doi => {
-          archivalResource.addSelfLink(new URI(s"http://doi.org/$doi").toASCIIString)
+          archivalResource.addSelfLink(new URI(s"https://doi.org/$doi").toASCIIString)
         })
 
         statement.addResource(archivalResource)


### PR DESCRIPTION
fixes EASY-1252 - Sword2 deposits moeten DOI kunnen aanmaken en terugleveren

#### When applied it will
* Read the DOI from the deposit.properties file on successful run and return the corresponding url to the client via the Sword statement. 

#### Where should the reviewer @DANS-KNAW/easy start?
StatementManagerImpl

#### How should this be manually tested?
You should build and deploy it on deasy and also build and deploy the related easy-ingest-flow. 
Depositing could be tested with the (related) easy-sword2-dans-examples. 
Check that on a successful ingest the DOI is returned in the statement, by an atom link. 

Note on building: use the new lib, until this is available on our maven repo, build the lib locally and change the version in the pom to: 1.x-SNAPSHOT instead of 1.0-beta-3

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-sword2-lib                      | [PR#8](https://github.com/DANS-KNAW/easy-sword2-lib/pull/8) 
easy-ingest-flow                      | [PR#21](https://github.com/DANS-KNAW/easy-ingest-flow/pull/21) 
easy-sword2-dans-examples                     | [PR#11](https://github.com/DANS-KNAW/easy-sword2-dans-examples/pull/11) 