### PR TITLE
remove ajp, upgrade Jetty to 9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,14 +125,12 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-ajp</artifactId>
+            <version>9.4.6.v20170531</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+            <version>9.4.6.v20170531</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -18,5 +18,3 @@ bag-store.base-url=
 bag-store.base-dir=
 support.mailaddress={{ easy_sword2_support_mail_address }}
 daemon.http.port={{ easy_sword2_http_port }}
-daemon.ajp.port={{ easy_sword2_ajp_port }}
-

--- a/src/main/scala/nl.knaw.dans.easy.sword2/Sword2Service.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Sword2Service.scala
@@ -17,7 +17,6 @@ package nl.knaw.dans.easy.sword2
 
 import nl.knaw.dans.easy.sword2.servlets._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.eclipse.jetty.ajp.Ajp13SocketConnector
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
 
@@ -56,13 +55,6 @@ class Sword2Service extends ApplicationSettings with DebugEnhancedLogging  {
   server.setHandler(context)
 
   info(s"HTTP port is $port")
-  if (properties.containsKey("daemon.ajp.port")) {
-    val ajp = new Ajp13SocketConnector()
-    val ajpPort = properties.getInt("daemon.ajp.port")
-    ajp.setPort(ajpPort)
-    server.addConnector(ajp)
-    info(s"AJP port is $ajpPort")
-  }
 
   def start(): Try[Unit] = Try {
     info("Starting processing thread ....")

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -16,4 +16,3 @@ bag-store.base-url=
 bag-store.base-dir=
 support.mailaddress=
 daemon.http.port=20100
-daemon.ajp.port=20101


### PR DESCRIPTION
~~fixes EASY-~~

#### When applied it will
* remove AJP support
* upgrade to Jetty 9.x

@DANS-KNAW/easy for review

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-dtap                      | [PR#104](https://github.com/DANS-KNAW/easy-dtap/pull/104)     | 
