### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,4 @@
-system "ansible-galaxy install --force --role-file #{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml"
+system "ansible-galaxy install --force --role-file #{File.dirname(File.expand_path(__FILE__))}/src/main/ansible/requirements.yml" if (ARGV[0] == "up" || ARGV[0] == "provision")
 Vagrant.configure(2) do |config|
    config.vm.define "test" do |test|
       test.vm.box = "geerlingguy/centos6"
@@ -8,6 +8,8 @@ Vagrant.configure(2) do |config|
       test.vm.provision "ansible" do |ansible|
         ansible.playbook = "src/main/ansible/vagrant.yml"
         ansible.config_file = "src/main/ansible/ansible.cfg"
+        ansible.compatibility_mode = "2.0"
+#        ansible.verbose = "vvvv"
       end
       test.vm.provider "virtualbox" do |vb|
         vb.gui = false

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -48,15 +48,15 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <artifactId>scalamock-scalatest-support_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-daemon</groupId>
@@ -118,6 +118,7 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
+            <version>4.11.0</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
@@ -125,7 +126,7 @@
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>
-            <artifactId>rxscala_2.11</artifactId>
+            <artifactId>rxscala_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationSettings.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationSettings.scala
@@ -19,9 +19,9 @@ import java.io.File
 import java.net.URI
 import java.util.regex.Pattern
 import javax.servlet.ServletException
+import nl.knaw.dans.lib.string.StringExtensions
 
 import org.apache.commons.configuration.PropertiesConfiguration
-import org.apache.commons.lang.StringUtils.{ isBlank, isNotBlank }
 
 trait ApplicationSettings {
   protected val properties = new PropertiesConfiguration()
@@ -46,9 +46,9 @@ trait ApplicationSettings {
   val bagStoreBaseUri = properties.getString("bag-store.base-url") // TODO: make File, check existence
   val bagStoreBaseDir = properties.getString("bag-store.base-dir") // TODO: make File, check existence
   var bagStoreSettings = Option.empty[BagStoreSettings]
-  if (isNotBlank(bagStoreBaseUri) || isNotBlank(bagStoreBaseDir)) {
-    if (isBlank(bagStoreBaseDir)) throw new RuntimeException("Only bag store base-url given, bag store base-directory missing")
-    if (isBlank(bagStoreBaseUri)) throw new RuntimeException("Only bag store base-directory given, bag store base-url missing")
+  if (!bagStoreBaseUri.isBlank || !bagStoreBaseDir.isBlank) {
+    if (bagStoreBaseDir.isBlank) throw new RuntimeException("Only bag store base-url given, bag store base-directory missing")
+    if (bagStoreBaseUri.isBlank) throw new RuntimeException("Only bag store base-directory given, bag store base-url missing")
     val baseDir = new File(bagStoreBaseDir)
     if (!baseDir.exists) throw new RuntimeException(s"Bag store base directory ${ baseDir.getAbsolutePath } doesn't exist")
     if (!baseDir.canRead) throw new RuntimeException(s"Bag store base directory ${ baseDir.getAbsolutePath } is not readable")

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
@@ -21,7 +21,7 @@ import java.util.regex.Pattern
 import javax.servlet.ServletException
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.apache.commons.lang.StringUtils.{ isBlank, isNotBlank }
+import nl.knaw.dans.lib.string.StringExtensions
 
 class ApplicationWiring(configuration: Configuration) extends DebugEnhancedLogging {
   val depositRootDir = new File(configuration.properties.getString("deposits.rootdir"))
@@ -43,9 +43,9 @@ class ApplicationWiring(configuration: Configuration) extends DebugEnhancedLoggi
   val bagStoreBaseUri = configuration.properties.getString("bag-store.base-url") // TODO: make File, check existence
   val bagStoreBaseDir = configuration.properties.getString("bag-store.base-dir") // TODO: make File, check existence
   var bagStoreSettings = Option.empty[BagStoreSettings]
-  if (isNotBlank(bagStoreBaseUri) || isNotBlank(bagStoreBaseDir)) {
-    if (isBlank(bagStoreBaseDir)) throw new RuntimeException("Only bag store base-url given, bag store base-directory missing")
-    if (isBlank(bagStoreBaseUri)) throw new RuntimeException("Only bag store base-directory given, bag store base-url missing")
+  if (!bagStoreBaseUri.isBlank || !bagStoreBaseDir.isBlank) {
+    if (bagStoreBaseDir.isBlank) throw new RuntimeException("Only bag store base-url given, bag store base-directory missing")
+    if (bagStoreBaseUri.isBlank) throw new RuntimeException("Only bag store base-directory given, bag store base-url missing")
     val baseDir = new File(bagStoreBaseDir)
     if (!baseDir.exists) throw new RuntimeException(s"Bag store base directory ${ baseDir.getAbsolutePath } doesn't exist")
     if (!baseDir.canRead) throw new RuntimeException(s"Bag store base directory ${ baseDir.getAbsolutePath } is not readable")

--- a/src/main/scala/nl.knaw.dans.easy.sword2/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Command.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.sword2
 
+import java.nio.file.Paths
+
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import resource.managed
@@ -26,7 +28,7 @@ import scala.util.{ Failure, Try }
 object Command extends App with DebugEnhancedLogging {
   type FeedBackMessage = String
 
-  private val configuration = Configuration()
+  private val configuration = Configuration(Paths.get(System.getProperty("app.home")))
   private val commandLine = new CommandLineOptions(args, configuration) {
     verify()
   }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Configuration.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.sword2
 
-import java.nio.file.{ Files, Paths }
+import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.configuration.PropertiesConfiguration
 import resource.managed
@@ -26,8 +26,7 @@ case class Configuration(version: String, properties: PropertiesConfiguration)
 
 object Configuration {
 
-  def apply(): Configuration = {
-    val home = Paths.get(System.getProperty("app.home"))
+  def apply(home: Path): Configuration = {
     val cfgPath = Seq(
       Paths.get(s"/etc/opt/dans.knaw.nl/easy-sword2/"),
       home.resolve("cfg"))

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ServiceStarter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ServiceStarter.scala
@@ -15,6 +15,9 @@
  */
 package nl.knaw.dans.easy.sword2
 
+import java.nio.file.Paths
+
+import nl.knaw.dans.lib.error.TryExtensions
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.daemon.{ Daemon, DaemonContext }
 
@@ -24,7 +27,7 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
 
   override def init(context: DaemonContext): Unit = {
     logger.info("Initializing service...")
-    val configuration = Configuration()
+    val configuration = Configuration(Paths.get(System.getProperty("app.home")))
     app = new EasySword2App(new ApplicationWiring(configuration))
     service = new EasySword2Service(configuration.properties.getInt("daemon.http.port"), app)
     logger.info("Service initialized.")

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -70,16 +70,5 @@ package object sword2 {
       }
     }
   }
-
-  // TODO copied from easy-bag-store
-  implicit class TryExtensions2[T](val t: Try[T]) extends AnyVal {
-    // TODO candidate for dans-scala-lib
-    def unsafeGetOrThrow: T = {
-      t match {
-        case Success(value) => value
-        case Failure(throwable) => throw throwable
-      }
-    }
-  }
 }
 

--- a/src/test/scala/nl.knaw.dans.easy.sword2/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/ReadmeSpec.scala
@@ -16,13 +16,12 @@
 package nl.knaw.dans.easy.sword2
 
 import java.io.{ ByteArrayOutputStream, File }
+import java.nio.file.Paths
 
 import org.scalatest._
 
 class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
-  System.setProperty("app.home", "src/main/assembly/dist") // Use the default settings in this test
-
-  private val clo = new CommandLineOptions(Array[String](), Configuration()) {
+  private val clo = new CommandLineOptions(Array[String](), Configuration(Paths.get("src/main/assembly/dist"))) {
     // avoids System.exit() in case of invalid arguments or "--help"
     override def verify(): Unit = {}
   }


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* provide a parameter to the `Configuration` constructor
* use the `dans-scala-lib` functions
* add `compatibility_mode` and extra if-clause to `Vagrantfile`

@DANS-KNAW/easy for review