### PR TITLE
EASY-1443. Make creation.timestamp an ISO-date.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-sword2</artifactId>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <name>EASY SWORD v2 Deposit Service</name>
     <url>https://github.com/DANS-KNAW/easy-sword2</url>
     <description>EASY SWORD v2 Deposit Service</description>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -51,7 +51,7 @@ class DepositProperties(depositId: String, depositorId: Option[String] = None)(i
     if (Files.exists(file)) props.load(file.toFile)
     else {
       props.setProperty("bag-store.bag-id", depositId)
-      props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString)
+      props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
     }
     debug(s"Using deposit.properties at $file")
     depositorId.foreach(props.setProperty("depositor.userId", _))

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -20,11 +20,14 @@ import java.net.URI
 import java.util.regex.Pattern
 
 import nl.knaw.dans.easy.sword2.DepositHandler.log
+import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import org.swordapp.server.DepositReceipt
 
 import scala.util.{ Failure, Success, Try }
 
 package object sword2 {
+  val dateTimeFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
+
   sealed abstract class AuthenticationSettings()
   case class LdapAuthSettings(ldapUrl: URI, usersParentEntry: String, swordEnabledAttributeName: String, swordEnabledAttributeValue: String) extends AuthenticationSettings
   case class SingleUserAuthSettings(user: String, password: String) extends AuthenticationSettings


### PR DESCRIPTION
Fixes EASY-1443

#### When applied it will
* Format the creation.timestamp as an ISO datetime UTC with millisecond precision.

@DANS-KNAW/easy 
