### PR TITLE
NO JIRA Configurable niceness

### DIFF
--- a/src/main/assembly/dist/install/easy-sword2-initd.sh
+++ b/src/main/assembly/dist/install/easy-sword2-initd.sh
@@ -9,7 +9,8 @@
 #                    and should be placed in /etc/init.d
 
 NAME="easy-sword2"
-EXEC="/usr/bin/jsvc"
+NICENESS=0
+EXEC="nice -n $NICENESS /usr/bin/jsvc"
 APPHOME="/opt/dans.knaw.nl/$NAME"
 JAVA_HOME="/usr/lib/jvm/jre"
 CLASSPATH="$APPHOME/bin/$NAME.jar"


### PR DESCRIPTION
#### When applied it will
*  Make the [niceness](https://linux.die.net/man/1/nice) with which the service runs configurable through the initd script.

In response to an issue on the production server about `easy-sword2` gobbling up too much processor time.

@DANS-KNAW/easy 
