### PR TITLE
EASY-1779: Add identifier.doi.registered=no to DepositProperties

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -52,6 +52,7 @@ class DepositProperties(depositId: String, depositorId: Option[String] = None)(i
     else {
       props.setProperty("bag-store.bag-id", depositId)
       props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
+      props.setProperty("identifier.doi.registered", "no")
     }
     debug(s"Using deposit.properties at $file")
     depositorId.foreach(props.setProperty("depositor.userId", _))


### PR DESCRIPTION
- [x] do manual test to verify that the field is added

Fixes EASY-1779-1781

#### When applied it will create deposit.properties files with indentifier.doi.registered=no

#### Where should the reviewer @DANS-KNAW/easy start?

the DepositProperties class

#### How should this be manually tested?

create a deposit and check if its properties file is created with the according field

