### PR TITLE
Easy-1804 set state of a deposit to uploaded, once all files are uploaded to the sword2 directory

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -248,7 +248,7 @@ object DepositHandler {
       log.info(s"[$id] Scheduling deposit to be finalized")
       val result = for {
         props <- DepositProperties(id)
-        _ <- props.setState(FINALIZING, "Deposit is being reassembled and validated")
+        _ <- props.setState(UPLOADED, "Deposit upload has been completed.")
         _ <- props.save()
       } yield ()
       result.get // Trigger exception if properties could not be updated

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -468,7 +468,7 @@ object DepositHandler {
     }
   }
 
-  def isOnPosixFileSystem(file: File): Boolean =  Try(Files.getPosixFilePermissions(file.toPath)).fold(_ => false, _ => true)
+  def isOnPosixFileSystem(file: File): Boolean = Try(Files.getPosixFilePermissions(file.toPath)).fold(_ => false, _ => true)
 
   def moveBagToStorage()(implicit settings: Settings, id: String): Try[File] =
     Try {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -468,12 +468,7 @@ object DepositHandler {
     }
   }
 
-  def isOnPosixFileSystem(file: File): Boolean = {
-    Try {
-      Files.getPosixFilePermissions(file.toPath)
-      true
-    }.getOrElse(false)
-  }
+  def isOnPosixFileSystem(file: File): Boolean =  Try(Files.getPosixFilePermissions(file.toPath)).fold(_ => false, _ => true)
 
   def moveBagToStorage()(implicit settings: Settings, id: String): Try[File] =
     Try {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -469,13 +469,10 @@ object DepositHandler {
   }
 
   def isOnPosixFileSystem(file: File): Boolean = {
-    try {
+    Try {
       Files.getPosixFilePermissions(file.toPath)
       true
-    }
-    catch {
-      case e: UnsupportedOperationException => false
-    }
+    }.getOrElse(false)
   }
 
   def moveBagToStorage()(implicit settings: Settings, id: String): Try[File] =

--- a/src/main/scala/nl.knaw.dans.easy.sword2/State.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/State.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.sword2
 
 object State extends Enumeration {
   type State = Value
-  val ARCHIVED, DRAFT, FAILED, FINALIZING, INVALID, REJECTED, SUBMITTED = Value
+  val ARCHIVED, DRAFT, FAILED, FINALIZING, INVALID, REJECTED, SUBMITTED, UPLOADED = Value
 
   def stringValues: Set[String] = this.values.map(_.toString)
 }

--- a/src/test/scala/nl.knaw.dans.easy.sword2/ResolveFetchItemsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/ResolveFetchItemsSpec.scala
@@ -20,7 +20,7 @@ import java.util.regex.Pattern
 
 import org.scalatest.Inside.inside
 
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
 class ResolveFetchItemsSpec extends Sword2Fixture with BagStoreFixture {
 

--- a/src/test/scala/nl.knaw.dans.easy.sword2/ResolveFetchItemsSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/ResolveFetchItemsSpec.scala
@@ -20,7 +20,7 @@ import java.util.regex.Pattern
 
 import org.scalatest.Inside.inside
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 
 class ResolveFetchItemsSpec extends Sword2Fixture with BagStoreFixture {
 


### PR DESCRIPTION
Fixes EASY-Easy 1804 uploaded
#### When applied it will
* will give states the status uploaded instead of finalizing once the file is uploaded

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#7_deposit-lib](https://github.com/DANS-KNAW/dans-deposit-lib/pull/7)     | ..
easy-                      | [EMD_PR#36](https://github.com/DANS-KNAW/easy-manage-deposit/pull/36)     | ..
