### PR TITLE
EASY-1802 give write permission to group for deposits 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,11 @@
             <groupId>org.joda</groupId>
             <artifactId>joda-convert</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.pathikrit</groupId>
+            <artifactId>better-files_2.12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -68,7 +68,7 @@ object DepositHandler {
       _ <- copyPayloadToFile(deposit, payload)
       _ <- doesHashMatch(payload, deposit.getMd5)
       _ <- handleDepositAsync(deposit)
-      _ <- FilesPermissionService.changePermissionsForDirectoryAndContent(deposit.getFile, settings.depositPermissions) // set file permissions after continued deposit is finished
+      _ <- FilesPermissionService.changePermissionsForDirectoryAndContent(deposit.getFile, settings.depositPermissions, id) // set file permissions after continued deposit is finished
       dr = createDepositReceipt(settings, id)
       _ = dr.setVerboseDescription("received successfully: " + deposit.getFilename + "; MD5: " + deposit.getMd5)
     } yield dr

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -65,7 +65,7 @@ object DepositHandler {
     val payload = Paths.get(settings.tempDir.toString, id, deposit.getFilename.split("/").last).toFile
     for {
       _ <- assertTempDirHasEnoughDiskspaceMarginForFile(payload)
-      _ <- copyPayloadToFile(deposit, payload)
+      _ <- copyPayloadToFile(deposit, payload) //TODO should file permissions also be set after this action?
       _ <- doesHashMatch(payload, deposit.getMd5)
       _ <- handleDepositAsync(deposit)
       _ <- FilesPermissionService.changePermissionsForDirectoryAndContent(deposit.getFile, settings.depositPermissions, id) // set file permissions after continued deposit is finished

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -479,12 +479,11 @@ object DepositHandler {
 
   def moveBagToStorage(depositDir: File, storageDir: File)(implicit settings: Settings, id: String): Try[File] = {
     log.debug(s"[$id] Moving bag to permanent storage")
-    val triedFile: Try[File] = for {
+    for {
       _ <- FilesPermissionService.changePermissionsForDirectoryAndContent(depositDir, settings.depositPermissions, id)
       file <- moveBagToStorage(depositDir.toPath.toAbsolutePath, storageDir.toPath.toAbsolutePath)
+          .recover { case e => throw new SwordError("Failed to move dataset to storage", e) }
     } yield file
-    triedFile
-      .recover { case e => throw new SwordError("Failed to move dataset to storage", e) }
   }
 
   def moveBagToStorage(depositDirPath: Path, storageDirPath: Path): Try[File] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -68,7 +68,7 @@ object DepositHandler {
       _ <- copyPayloadToFile(deposit, payload) //TODO should file permissions also be set after this action?
       _ <- doesHashMatch(payload, deposit.getMd5)
       _ <- handleDepositAsync(deposit)
-      _ <- FilesPermissionService.changePermissionsForDirectoryAndContent(deposit.getFile, settings.depositPermissions, id) // set file permissions after continued deposit is finished
+      _ <- FilesPermission.changePermissionsRecursively(deposit.getFile, settings.depositPermissions, id) // set file permissions after continued deposit is finished
       dr = createDepositReceipt(settings, id)
       _ = dr.setVerboseDescription("received successfully: " + deposit.getFilename + "; MD5: " + deposit.getMd5)
     } yield dr
@@ -479,7 +479,7 @@ object DepositHandler {
 
   def moveBagToStorage(depositDir: File, storageDir: File)(implicit settings: Settings, id: String): Try[File] = {
     log.debug(s"[$id] Moving bag to permanent storage")
-    FilesPermissionService.changePermissionsForDirectoryAndContent(depositDir, settings.depositPermissions, id)
+    FilesPermission.changePermissionsRecursively(depositDir, settings.depositPermissions, id)
       .map(_ =>  Files.move(depositDir.toPath.toAbsolutePath, storageDir.toPath.toAbsolutePath).toFile)
       .recoverWith { case e => Failure(new SwordError("Failed to move dataset to storage", e)) }
   }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermissionService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermissionService.scala
@@ -41,7 +41,7 @@ object FilesPermissionService {
         case usoe: UnsupportedOperationException => log.error("Not on a POSIX supported file system"); FileVisitResult.TERMINATE
         case cce: ClassCastException => log.error("No file permission elements in set"); FileVisitResult.TERMINATE
         case ioe: IOException => log.error(s"Could not set file permissions on $path"); FileVisitResult.TERMINATE
-        case se: SecurityException => log.error(s"Not enough privileges to set file permissions on $path"); FileVisitResult.TERMINATE
+        case se: SecurityException => log.error(s"Not enough privileges to set file permissions on $path",se); FileVisitResult.TERMINATE
       }
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermissionService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermissionService.scala
@@ -25,15 +25,15 @@ import scala.util.Try
 
 object FilesPermissionService {
 
-  def changePermissionsForDirectoryAndContent(depositDir: File, permissions: String): Try[Unit] = Try {
+  def changePermissionsForDirectoryAndContent(depositDir: File, permissions: String, id: String): Try[Unit] = Try {
     if (isOnPosixFileSystem(depositDir))
-      Files.walkFileTree(depositDir.toPath, ChangePermissionsForDirectoryAndContent(permissions))
+      Files.walkFileTree(depositDir.toPath, ChangePermissionsForDirectoryAndContent(permissions, id))
   }
 
   // previous classname MakeAllGroupWritable was deceptive as the argument (posix permission string) can be something else than rwxrwx---
-  case class ChangePermissionsForDirectoryAndContent(permissions: String) extends SimpleFileVisitor[Path] {
+  case class ChangePermissionsForDirectoryAndContent(permissions: String, id: String) extends SimpleFileVisitor[Path] {
     override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
-      log.debug(s"Setting the following permissions $permissions on file $path")
+      log.debug(s"[$id] Setting the following permissions $permissions on file $path")
       try {
         Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(permissions))
         FileVisitResult.CONTINUE
@@ -46,7 +46,7 @@ object FilesPermissionService {
     }
 
     override def postVisitDirectory(dir: Path, ex: IOException): FileVisitResult = {
-      log.debug(s"Setting the following permissions $permissions on directory $dir")
+      log.debug(s"[$id] Setting the following permissions $permissions on directory $dir")
       Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString(permissions))
       if (ex == null) FileVisitResult.CONTINUE
       else FileVisitResult.TERMINATE

--- a/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermissionService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermissionService.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.sword2
+
+import java.io.{ File, IOException }
+import java.nio.file.{ FileVisitResult, Files, Path, SimpleFileVisitor }
+import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermissions }
+
+import nl.knaw.dans.easy.sword2.DepositHandler.{ isOnPosixFileSystem, log }
+
+import scala.util.Try
+
+object FilesPermissionService {
+
+  def changePermissionsForDirectoryAndContent(depositDir: File, permissions: String): Try[Unit] = Try {
+    if (isOnPosixFileSystem(depositDir))
+      Files.walkFileTree(depositDir.toPath, ChangePermissionsForDirectoryAndContent(permissions))
+  }
+
+  // previous classname MakeAllGroupWritable was deceptive as the argument (posix permission string) can be something else than rwxrwx---
+  case class ChangePermissionsForDirectoryAndContent(permissions: String) extends SimpleFileVisitor[Path] {
+    override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      log.debug(s"Setting the following permissions $permissions on file $path")
+      try {
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(permissions))
+        FileVisitResult.CONTINUE
+      } catch {
+        case usoe: UnsupportedOperationException => log.error("Not on a POSIX supported file system"); FileVisitResult.TERMINATE
+        case cce: ClassCastException => log.error("No file permission elements in set"); FileVisitResult.TERMINATE
+        case ioe: IOException => log.error(s"Could not set file permissions on $path"); FileVisitResult.TERMINATE
+        case se: SecurityException => log.error(s"Not enough privileges to set file permissions on $path"); FileVisitResult.TERMINATE
+      }
+    }
+
+    override def postVisitDirectory(dir: Path, ex: IOException): FileVisitResult = {
+      log.debug(s"Setting the following permissions $permissions on directory $dir")
+      Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString(permissions))
+      if (ex == null) FileVisitResult.CONTINUE
+      else FileVisitResult.TERMINATE
+    }
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.sword2/BagStoreFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/BagStoreFixture.scala
@@ -23,5 +23,3 @@ trait BagStoreFixture {
   val baseUrl = "http://deasy.dans.knaw.nl/aips"
   implicit val bagStoreSettings = Some(BagStoreSettings(baseDir, baseUrl))
 }
-
-

--- a/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
@@ -45,7 +45,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
   "changePermissionsForAllDepositContent" should "give write access to the group when given string rwxrwx---" in {
     giveDirectoryAndAllContentOnlyOwnerRights(bagSequenceDirPath)
 
-    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerAndGroupRightsString, bagSequenceId)
+    FilesPermission.changePermissionsRecursively(bagSequenceDir.toJava, ownerAndGroupRightsString, bagSequenceId)
     Files.getPosixFilePermissions(bagSequenceDirPath) should contain only(
       PosixFilePermission.OWNER_EXECUTE,
       PosixFilePermission.OWNER_READ,
@@ -59,7 +59,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
   "changePermissionsForAllDepositContent" should "not give write access to the group when given string rwx------" in {
     giveDirectoryAndAllContentOnlyOwnerRights(bagSequenceDirPath)
 
-    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerRights, bagSequenceId)
+    FilesPermission.changePermissionsRecursively(bagSequenceDir.toJava, ownerRights, bagSequenceId)
     Files.getPosixFilePermissions(bagSequenceDirPath) should contain only(
       PosixFilePermission.OWNER_EXECUTE,
       PosixFilePermission.OWNER_READ,

--- a/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
@@ -66,7 +66,6 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
     )
   }
 
-
   private def giveDirectoryAndAllContentOnlyOwnerRights(depositDir: Path) = {
     val onlyOwnerPerm: util.Set[PosixFilePermission] = new util.HashSet()
     onlyOwnerPerm.add(PosixFilePermission.OWNER_EXECUTE)

--- a/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.sword2
+
+import java.nio.file._
+import java.nio.file.attribute.PosixFilePermission
+import java.util
+
+import org.scalatest.BeforeAndAfterEach
+
+class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEach {
+
+  lazy private val inputDir = {
+    val path = testDir / "input/"
+    if (path.exists) path.delete()
+    path.createDirectories()
+    path
+  }
+  private val bagSequenceDir = inputDir / "bag-sequence"
+  private val bagSequenceDirPath = bagSequenceDir.toJava.toPath
+  private val ownerAndGroupRightsString = "rwxrwx---"
+  private val ownerRights = "rxw------"
+
+  override def beforeEach: Unit = {
+    super.beforeEach()
+    inputDir.clear()
+    better.files.File(getClass.getResource("/input/").toURI).copyTo(inputDir)
+  }
+
+  "changePermissionsForAllDepositContent" should "give write access to the group when given string rwxrwx---" in {
+    giveDirectoryAndAllContentOnlyOwnerRights(bagSequenceDirPath)
+
+    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerAndGroupRightsString)
+    Files.getPosixFilePermissions(bagSequenceDirPath) should contain only(
+      PosixFilePermission.OWNER_EXECUTE,
+      PosixFilePermission.OWNER_READ,
+      PosixFilePermission.OWNER_WRITE,
+      PosixFilePermission.GROUP_EXECUTE,
+      PosixFilePermission.GROUP_READ,
+      PosixFilePermission.GROUP_WRITE,
+    )
+  }
+
+  "changePermissionsForAllDepositContent" should "not give write access to the group when given string rwx------" in {
+    giveDirectoryAndAllContentOnlyOwnerRights(bagSequenceDirPath)
+
+    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerRights)
+    Files.getPosixFilePermissions(bagSequenceDirPath) should contain only(
+      PosixFilePermission.OWNER_EXECUTE,
+      PosixFilePermission.OWNER_READ,
+      PosixFilePermission.OWNER_WRITE,
+    )
+  }
+
+
+  private def giveDirectoryAndAllContentOnlyOwnerRights(depositDir: Path) = {
+    val onlyOwnerPerm: util.Set[PosixFilePermission] = new util.HashSet()
+    onlyOwnerPerm.add(PosixFilePermission.OWNER_EXECUTE)
+    onlyOwnerPerm.add(PosixFilePermission.OWNER_READ)
+    onlyOwnerPerm.add(PosixFilePermission.OWNER_WRITE)
+    Files.setPosixFilePermissions(bagSequenceDir.toJava.toPath, onlyOwnerPerm) // all files in the test dir start with group access
+
+    Files.getPosixFilePermissions(bagSequenceDir.toJava.toPath) should contain only(
+      PosixFilePermission.OWNER_EXECUTE,
+      PosixFilePermission.OWNER_READ,
+      PosixFilePermission.OWNER_WRITE,
+    )
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
@@ -31,7 +31,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
   }
   private val bagSequenceDir = inputDir / "bag-sequence"
   private val bagSequenceId = "bag-sequence"
-  private val bagSequenceDirPath = bagSequenceDir.toJava.toPath
+  private val bagSequenceDirPath = bagSequenceDir.path
   private val ownerAndGroupRightsString = "rwxrwx---"
   private val ownerRights = "rxw------"
 
@@ -72,9 +72,9 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
     onlyOwnerPerm.add(PosixFilePermission.OWNER_EXECUTE)
     onlyOwnerPerm.add(PosixFilePermission.OWNER_READ)
     onlyOwnerPerm.add(PosixFilePermission.OWNER_WRITE)
-    Files.setPosixFilePermissions(bagSequenceDir.toJava.toPath, onlyOwnerPerm) // all files in the test dir start with group access
+    Files.setPosixFilePermissions(bagSequenceDir.path, onlyOwnerPerm) // all files in the test dir start with group access
 
-    Files.getPosixFilePermissions(bagSequenceDir.toJava.toPath) should contain only(
+    Files.getPosixFilePermissions(bagSequenceDir.path) should contain only(
       PosixFilePermission.OWNER_EXECUTE,
       PosixFilePermission.OWNER_READ,
       PosixFilePermission.OWNER_WRITE,

--- a/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
@@ -30,6 +30,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
     path
   }
   private val bagSequenceDir = inputDir / "bag-sequence"
+  private val bagSequenceId = "bag-sequence"
   private val bagSequenceDirPath = bagSequenceDir.toJava.toPath
   private val ownerAndGroupRightsString = "rwxrwx---"
   private val ownerRights = "rxw------"
@@ -43,7 +44,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
   "changePermissionsForAllDepositContent" should "give write access to the group when given string rwxrwx---" in {
     giveDirectoryAndAllContentOnlyOwnerRights(bagSequenceDirPath)
 
-    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerAndGroupRightsString)
+    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerAndGroupRightsString, bagSequenceId)
     Files.getPosixFilePermissions(bagSequenceDirPath) should contain only(
       PosixFilePermission.OWNER_EXECUTE,
       PosixFilePermission.OWNER_READ,
@@ -57,7 +58,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
   "changePermissionsForAllDepositContent" should "not give write access to the group when given string rwx------" in {
     giveDirectoryAndAllContentOnlyOwnerRights(bagSequenceDirPath)
 
-    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerRights)
+    FilesPermissionService.changePermissionsForDirectoryAndContent(bagSequenceDir.toJava, ownerRights, bagSequenceId)
     Files.getPosixFilePermissions(bagSequenceDirPath) should contain only(
       PosixFilePermission.OWNER_EXECUTE,
       PosixFilePermission.OWNER_READ,

--- a/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/FilePermissionServiceSpec.scala
@@ -15,10 +15,11 @@
  */
 package nl.knaw.dans.easy.sword2
 
-import java.nio.file._
 import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.{ Files, Path }
 import java.util
 
+import better.files.File
 import org.scalatest.BeforeAndAfterEach
 
 class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEach {
@@ -38,7 +39,7 @@ class FilePermissionServiceSpec extends TestSupportFixture with BeforeAndAfterEa
   override def beforeEach: Unit = {
     super.beforeEach()
     inputDir.clear()
-    better.files.File(getClass.getResource("/input/").toURI).copyTo(inputDir)
+    File(getClass.getResource("/input/").toURI).copyTo(inputDir)
   }
 
   "changePermissionsForAllDepositContent" should "give write access to the group when given string rwxrwx---" in {

--- a/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.sword2
+
+import better.files.File
+import better.files.File.currentWorkingDirectory
+import org.scalatest.enablers.Existence
+import org.scalatest.{ FlatSpec, Matchers, OptionValues }
+
+trait TestSupportFixture extends FlatSpec with Matchers with OptionValues {
+  implicit def existenceOfFile[FILE <: better.files.File]: Existence[FILE] = _.exists
+
+  lazy val testDir: File = {
+    val path = currentWorkingDirectory / s"target/test/${ getClass.getSimpleName }"
+    if (path.exists) path.delete()
+    path.createDirectories()
+    path
+  }
+}


### PR DESCRIPTION
Fixes EASY-1802

#### When applied it will
* give write acces to the group
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

try to modify/ delete a deposit and its content on  deasy/ teasy in the sword tmp folder
