### PR TITLE
EASY-1805: reschedule deposits on not enough disk space

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/Authentication.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Authentication.scala
@@ -78,7 +78,7 @@ object Authentication {
   }
 
   @throws(classOf[SwordAuthException])
-  def checkThatUserIsOwnerOfDeposit(id: String, user: String, msg: String)(implicit settings: Settings): Try[Unit] = {
+  def checkThatUserIsOwnerOfDeposit(id: DepositId, user: String, msg: String)(implicit settings: Settings): Try[Unit] = {
     for {
       props <- DepositProperties(id)
       depositor <- props.getDepositorId

--- a/src/main/scala/nl.knaw.dans.easy.sword2/CollectionDepositManagerImpl.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/CollectionDepositManagerImpl.scala
@@ -51,7 +51,7 @@ class CollectionDepositManagerImpl extends CollectionDepositManager {
       throw new SwordError("http://purl.org/net/sword/error/MethodNotAllowed", 405, s"Not a valid collection: $collectionPath (valid collection is ${ settings.collectionPath }")
   }
 
-  private def setDepositStateToDraft(id: String, userId: String)(implicit settings: Settings): Try[Unit] = {
+  private def setDepositStateToDraft(id: DepositId, userId: String)(implicit settings: Settings): Try[Unit] = {
     for {
       props <- DepositProperties(id, Some(userId))
       props <- props.setState(DRAFT, "Deposit is open for additional data")

--- a/src/main/scala/nl.knaw.dans.easy.sword2/CollectionListManagerImpl.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/CollectionListManagerImpl.scala
@@ -37,7 +37,7 @@ class CollectionListManagerImpl extends CollectionListManager {
     }
   }
 
-  private def createEntry(id: String, abdera: Abdera): Entry = abdera.newEntry // TODO: implement me
+  private def createEntry(id: DepositId, abdera: Abdera): Entry = abdera.newEntry // TODO: implement me
 
   private def createEmptyEntry(abdera: Abdera): Entry = abdera.newEntry
 }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -121,7 +121,7 @@ object DepositHandler {
           // replacing sensitive data
           _ <- cleanupFiles(depositDir, INVALID)
         } yield ()
-      case NotEnoughDiskSpaceException(_, msg, cause) =>
+      case e @ NotEnoughDiskSpaceException(_, msg, cause) =>
         log.error(s"[$id] Rejected deposit", cause)
         for {
           // Currently, the only reason for SWORD 2 to reject a deposit, is insufficient disk space,
@@ -183,7 +183,7 @@ object DepositHandler {
       val availableDiskSize = Files.getFileStore(file.toPath).getUsableSpace
       log.debug(s"[$id] Available (usable) disk space currently $availableDiskSize bytes. Spaces needed: $uncompressedSize bytes. Margin required: ${ settings.marginDiskSpace } bytes.")
       if (uncompressedSize + settings.marginDiskSpace > availableDiskSize)
-        Failure(NotEnoughDiskSpaceException(id, "Not enough disk space to process deposit.",
+        Failure(NotEnoughDiskSpaceException(id,
           new IllegalStateException(s"Required disk space for unzipping: ${ uncompressedSize + settings.marginDiskSpace } (including ${ settings.marginDiskSpace } margin). Available: $availableDiskSize")))
       else Success(())
     }
@@ -195,7 +195,7 @@ object DepositHandler {
           val availableDiskSize = Files.getFileStore(f.toPath).getUsableSpace
           log.debug(s"[$id] Available (usable) disk space currently $availableDiskSize bytes. Spaces needed: $requiredSpace bytes. Margin required: ${ settings.marginDiskSpace } bytes.")
           if (requiredSpace + settings.marginDiskSpace > availableDiskSize)
-            Failure(NotEnoughDiskSpaceException(id, "Not enough disk space to process deposit.",
+            Failure(NotEnoughDiskSpaceException(id,
               new IllegalStateException(s"Required disk space for concatenating: ${ requiredSpace + settings.marginDiskSpace } (including ${ settings.marginDiskSpace } margin). Available: $availableDiskSize")))
           else Success(())
       }.getOrElse(Success(()))

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -121,7 +121,7 @@ object DepositHandler {
           // replacing sensitive data
           _ <- cleanupFiles(depositDir, INVALID)
         } yield ()
-      case RejectedDepositException(_, msg, cause) =>
+      case NotEnoughDiskSpaceException(_, msg, cause) =>
         log.error(s"[$id] Rejected deposit", cause)
         for {
           // Currently, the only reason for SWORD 2 to reject a deposit, is insufficient disk space,
@@ -183,7 +183,7 @@ object DepositHandler {
       val availableDiskSize = Files.getFileStore(file.toPath).getUsableSpace
       log.debug(s"[$id] Available (usable) disk space currently $availableDiskSize bytes. Spaces needed: $uncompressedSize bytes. Margin required: ${ settings.marginDiskSpace } bytes.")
       if (uncompressedSize + settings.marginDiskSpace > availableDiskSize)
-        Failure(RejectedDepositException(id, "Not enough disk space to process deposit.",
+        Failure(NotEnoughDiskSpaceException(id, "Not enough disk space to process deposit.",
           new IllegalStateException(s"Required disk space for unzipping: ${ uncompressedSize + settings.marginDiskSpace } (including ${ settings.marginDiskSpace } margin). Available: $availableDiskSize")))
       else Success(())
     }
@@ -195,7 +195,7 @@ object DepositHandler {
           val availableDiskSize = Files.getFileStore(f.toPath).getUsableSpace
           log.debug(s"[$id] Available (usable) disk space currently $availableDiskSize bytes. Spaces needed: $requiredSpace bytes. Margin required: ${ settings.marginDiskSpace } bytes.")
           if (requiredSpace + settings.marginDiskSpace > availableDiskSize)
-            Failure(RejectedDepositException(id, "Not enough disk space to process deposit.",
+            Failure(NotEnoughDiskSpaceException(id, "Not enough disk space to process deposit.",
               new IllegalStateException(s"Required disk space for concatenating: ${ requiredSpace + settings.marginDiskSpace } (including ${ settings.marginDiskSpace } margin). Available: $availableDiskSize")))
           else Success(())
       }.getOrElse(Success(()))

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -91,14 +91,14 @@ object DepositHandler {
       throw new SwordError(503)
   }
 
-  def finalizeDeposit(mimeType: MimeType)(implicit settings: Settings, id: DepositId): Try[Unit] = {
+  def finalizeDeposit(mimetype: MimeType)(implicit settings: Settings, id: DepositId): Try[Unit] = {
     log.info(s"[$id] Finalizing deposit")
     implicit val bagStoreSettings: Option[BagStoreSettings] = settings.bagStoreSettings
     val depositDir = new File(settings.tempDir, id)
     lazy val storageDir = new File(settings.depositRootDir, id)
 
     val result = for {
-      _ <- extractBag(depositDir, mimeType)
+      _ <- extractBag(depositDir, mimetype)
       bagDir <- getBagDir(depositDir)
       _ <- checkFetchItemUrls(bagDir, settings.urlPattern)
       _ <- checkBagVirtualValidity(bagDir)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -122,7 +122,7 @@ object DepositHandler {
           _ <- cleanupFiles(depositDir, INVALID)
         } yield ()
       case e @ NotEnoughDiskSpaceException(_, msg, cause) =>
-        log.error(s"[$id] Rejected deposit", cause)
+        log.error(s"[$id] $msg", cause)
         for {
           // Currently, the only reason for SWORD 2 to reject a deposit, is insufficient disk space,
           // so we clean up, here.

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -121,8 +121,8 @@ object DepositHandler {
           // replacing sensitive data
           _ <- cleanupFiles(depositDir, INVALID)
         } yield ()
-      case NotEnoughDiskSpaceException(_, msg, cause) =>
-        log.error(s"[$id] $msg", cause)
+      case e: NotEnoughDiskSpaceException =>
+        log.error(s"[$id] ${ e.getMessage }", e.getCause)
         log.info(s"[$id] rescheduling while waiting for more diskspace")
         depositProcessingStream.onNext((id, mimetype))
       case NonFatal(e) =>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -33,7 +33,7 @@ import scala.util.{ Failure, Success, Try }
  * @param depositId the deposit of which to load the properties
  * @param settings  application settings
  */
-class DepositProperties(depositId: String, depositorId: Option[String] = None)(implicit settings: Settings) extends DebugEnhancedLogging {
+class DepositProperties(depositId: DepositId, depositorId: Option[String] = None)(implicit settings: Settings) extends DebugEnhancedLogging {
 
   import DepositProperties._
 
@@ -128,7 +128,7 @@ class DepositProperties(depositId: String, depositorId: Option[String] = None)(i
 object DepositProperties {
   val FILENAME = "deposit.properties"
 
-  def apply(depositId: String, depositorId: Option[String] = None)(implicit settings: Settings): Try[DepositProperties] = Try {
+  def apply(depositId: DepositId, depositorId: Option[String] = None)(implicit settings: Settings): Try[DepositProperties] = Try {
     new DepositProperties(depositId, depositorId)
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/SwordID.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/SwordID.scala
@@ -22,14 +22,14 @@ import org.swordapp.server.SwordError
 import scala.util.{ Failure, Success, Try }
 
 object SwordID {
-  def generate(maybeSlug: Option[String], user: String)(implicit settings: Settings): Try[String] = Try {
+  def generate(maybeSlug: Option[String], user: String)(implicit settings: Settings): Try[DepositId] = Try {
     maybeSlug match {
       case Some(slug) => slug
       case None => UUID.randomUUID().toString
     }
   }
 
-  def extract(IRI: String): Try[String] = {
+  def extract(IRI: String): Try[DepositId] = {
     val parts = IRI.split("/")
     if (parts.length < 1) Failure(new SwordError(404))
     else Success(parts.last)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -58,7 +58,7 @@ package object sword2 {
   case class BagStoreSettings(baseDir: String, baseUrl: String)
 
   case class InvalidDepositException(id: DepositId, msg: String, cause: Throwable = null) extends Exception(msg, cause)
-  case class RejectedDepositException(id: DepositId, msg: String, cause: Throwable = null) extends Exception(msg, cause)
+  case class NotEnoughDiskSpaceException(id: DepositId, msg: String, cause: Throwable) extends Exception(msg, cause)
 
   implicit class FileOps(val thisFile: File) extends AnyVal {
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -29,6 +29,9 @@ import scala.util.{ Failure, Success, Try }
 package object sword2 {
   val dateTimeFormatter: DateTimeFormatter = ISODateTimeFormat.dateTime()
 
+  type DepositId = String
+  type MimeType = String
+
   sealed abstract class AuthenticationSettings()
   case class LdapAuthSettings(ldapUrl: URI, usersParentEntry: String, swordEnabledAttributeName: String, swordEnabledAttributeValue: String) extends AuthenticationSettings
   case class SingleUserAuthSettings(user: String, password: String) extends AuthenticationSettings
@@ -54,8 +57,8 @@ package object sword2 {
 
   case class BagStoreSettings(baseDir: String, baseUrl: String)
 
-  case class InvalidDepositException(id: String, msg: String, cause: Throwable = null) extends Exception(msg, cause)
-  case class RejectedDepositException(id: String, msg: String, cause: Throwable = null) extends Exception(msg, cause)
+  case class InvalidDepositException(id: DepositId, msg: String, cause: Throwable = null) extends Exception(msg, cause)
+  case class RejectedDepositException(id: DepositId, msg: String, cause: Throwable = null) extends Exception(msg, cause)
 
   implicit class FileOps(val thisFile: File) extends AnyVal {
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -59,11 +59,6 @@ package object sword2 {
 
   case class InvalidDepositException(id: DepositId, msg: String, cause: Throwable = null) extends Exception(msg, cause)
   case class NotEnoughDiskSpaceException(id: DepositId, cause: Throwable) extends Exception("Not enough disk space to process deposit.", cause)
-  object NotEnoughDiskSpaceException {
-    def unapply(arg: NotEnoughDiskSpaceException): Option[(DepositId, String, Throwable)] = {
-      Some(arg.id, arg.getMessage, arg.cause)
-    }
-  }
 
   implicit class FileOps(val thisFile: File) extends AnyVal {
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -58,7 +58,12 @@ package object sword2 {
   case class BagStoreSettings(baseDir: String, baseUrl: String)
 
   case class InvalidDepositException(id: DepositId, msg: String, cause: Throwable = null) extends Exception(msg, cause)
-  case class NotEnoughDiskSpaceException(id: DepositId, msg: String, cause: Throwable) extends Exception(msg, cause)
+  case class NotEnoughDiskSpaceException(id: DepositId, cause: Throwable) extends Exception("Not enough disk space to process deposit.", cause)
+  object NotEnoughDiskSpaceException {
+    def unapply(arg: NotEnoughDiskSpaceException): Option[(DepositId, String, Throwable)] = {
+      Some(arg.id, arg.getMessage, arg.cause)
+    }
+  }
 
   implicit class FileOps(val thisFile: File) extends AnyVal {
 


### PR DESCRIPTION
Fixes EASY-1805

#### When applied it will
* use type aliases for `DepositId` and `MimeType`
* let `depositProcessingStream` take a tuple of `DepositId` and `MimeType` rather than `DepositId` and `Deposit`
* rename `RejectedDepositException` to `NotEnoughDiskSpaceException`
* when `NotEnoughDiskSpaceException` is encountered, reschedule the deposit, rather than `REJECT` it.

@DANS-KNAW/easy for review

* [x] wait for #109 to be merged