### PR TITLE
EASY-1762: Check that provided dans-doi was already minted / registered => add dans-doi.action property

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -53,6 +53,7 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
       props.setProperty("bag-store.bag-id", depositId)
       props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
       props.setProperty("identifier.dans-doi.registered", "no")
+      props.setProperty("identifier.dans-doi.action", "create")
     }
     debug(s"Using deposit.properties at $file")
     depositorId.foreach(props.setProperty("depositor.userId", _))


### PR DESCRIPTION
Fixes EASY-1762

#### When applied it will
* initialise deposit.properties with property  dentifier.dans-doi.action = create

Where should the reviewer @DANS-KNAW/easy start?

repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-ingest-flow                    | [PR#87](https://github.com/DANS-KNAW/easy-ingest-flow/pull/87)| ingest-flow uses action property

