### PR TITLE
no-Jira: fix for compiler warning in FilePermissions (EASY-1864)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermission.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/FilesPermission.scala
@@ -22,6 +22,7 @@ import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermissions }
 import nl.knaw.dans.easy.sword2.DepositHandler.isOnPosixFileSystem
 import nl.knaw.dans.lib.error._
 import org.slf4j.{ Logger, LoggerFactory }
+import scala.language.postfixOps
 
 import scala.util.Try
 


### PR DESCRIPTION
Fixes EASY-1864 compiler warning in FilePermission object

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-sword2                     | [PR#116](https://github.com/DANS-KNAW/easy-sword2/pull/116)     | ..