### PR TITLE
NO-JIRA: Sword2 logback-service parser error

### DIFF
--- a/src/main/assembly/dist/cfg/logback-service.xml
+++ b/src/main/assembly/dist/cfg/logback-service.xml
@@ -8,7 +8,7 @@
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>[%date{ISO8601}] %-5level [..%t8.8] %msg%n%ex</pattern>
+            <pattern>[%date{ISO8601}] %-5level [%8.8t] %msg%n%ex</pattern>
         </encoder>
     </appender>
     <root level="warn">


### PR DESCRIPTION
#### When applied it will
* now the sword2 logs a parser error instead of the class name (Richard Kruithof found this fix wil resolve this).

#### Where should the reviewer @DANS-KNAW/easy start?