### PR TITLE
NO JIRA. Refactoring: rename contentType to easy-sword2.client-message.content-type

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -99,7 +99,7 @@ object DepositHandler {
   private def getContentType(dir: File)(implicit settings: Settings): Try[String] = {
     for {
       props <- DepositProperties(dir.getName)
-      contentType <- props.getContentType
+      contentType <- props.getClientMessageContentType
     } yield contentType
   }
 
@@ -188,6 +188,7 @@ object DepositHandler {
       _ <- SampleTestData.sampleData(id, depositDir, props)(settings.sample)
       _ <- removeZipFiles(depositDir)
       _ <- moveBagToStorage(depositDir, storageDir)
+      _ <- props.removeClientMessageContentType()
     } yield ()
 
     result.doIfSuccess(_ => log.info(s"[$id] Done finalizing deposit")).recover {
@@ -364,7 +365,7 @@ object DepositHandler {
       for {
         props <- DepositProperties(id)
         _ <- props.setState(UPLOADED, "Deposit upload has been completed.")
-        _ <- props.setContentType(deposit.getMimeType)
+        _ <- props.setClientMessageContentType(deposit.getMimeType)
         _ <- props.save()
       } yield depositProcessingStream.onNext((id, deposit.getMimeType))
     }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -189,6 +189,7 @@ object DepositHandler {
       _ <- removeZipFiles(depositDir)
       _ <- moveBagToStorage(depositDir, storageDir)
       _ <- props.removeClientMessageContentType()
+      _ <- props.save()
     } yield ()
 
     result.doIfSuccess(_ => log.info(s"[$id] Done finalizing deposit")).recover {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -187,9 +187,10 @@ object DepositHandler {
       _ <- props.save()
       _ <- SampleTestData.sampleData(id, depositDir, props)(settings.sample)
       _ <- removeZipFiles(depositDir)
-      _ <- moveBagToStorage(depositDir, storageDir)
+      // ATTENTION: first remove content-type property and THEN move bag to ingest-flow-inbox!!
       _ <- props.removeClientMessageContentType()
       _ <- props.save()
+      _ <- moveBagToStorage(depositDir, storageDir)
     } yield ()
 
     result.doIfSuccess(_ => log.info(s"[$id] Done finalizing deposit")).recover {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -99,8 +99,8 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
   }
 
   def removeClientMessageContentType(): Try[DepositProperties] = Try {
-    properties.setProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY, null)
-    properties.setProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY_OLD, null) // Also clean up old contentType property if still found
+    properties.clearProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY)
+    properties.clearProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY_OLD) // Also clean up old contentType property if still found
     this
   }
 


### PR DESCRIPTION
NO JIRA.

Rename a temporary property  in `deposit.properties` and clean it up after use, to avoid confusion.

### Some background
The property is used to record what type of messages the sword client has been sending, i.e. `application/zip` or `application/octet-stream`. This information is needed in the "finalizing" stage. Since deposits can be pushed back onto the finalization queue if there is not enough room for them to be processed, this means that the information must be saved to `deposit.properties`, so that a restart of `easy-sword2` will not cause those deposits never to be processed.

- [x] Test

#### When applied it will
* Rename `contentType` to `easy-sword2.client-message.content-type`
* Make sure the `easy-sword2` still understands the old property, too.
* Ensure that `easy-sword2` cleans up after successfully finalizing, as the property will not be useful after that point. 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

