### PR TITLE
EASY-1954: sword 2 does not set properties:  identifier.dans-doi.registered and identifier.dans-doi.action

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -53,8 +53,6 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
     else {
       props.setProperty("bag-store.bag-id", depositId)
       props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
-      props.setProperty("identifier.dans-doi.registered", "no")
-      props.setProperty("identifier.dans-doi.action", "create")
     }
     debug(s"Using deposit.properties at $file")
     depositorId.foreach(props.setProperty("depositor.userId", _))


### PR DESCRIPTION
Fixes EASY-1954

#### When applied it will
* it will not set the properties:  identifier.dans-doi.registered and identifier.dans-doi.action
#### Where should the reviewer @DANS-KNAW/easy start?