### PR TITLE
EASY-2082 Dryad ZipException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
         <dependency>
             <groupId>com.github.pathikrit</groupId>
             <artifactId>better-files_2.12</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -289,9 +289,9 @@ object DepositHandler {
     }
 
     def extract(file: File, outputPath: String): Unit = {
-      val f = better.files.File(file.getAbsolutePath)
+      import better.files._
       implicit val charset: Charset = StandardCharsets.UTF_8
-      f unzipTo better.files.File(outputPath)
+      file.toScala unzipTo outputPath.toFile
     }
 
     def getSequenceNumber(f: File): Int = {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.sword2
 
 import java.io.{ File, IOException }
 import java.net.{ MalformedURLException, URL, UnknownHostException }
-import java.nio.charset.StandardCharsets
+import java.nio.charset.{ Charset, StandardCharsets }
 import java.nio.file._
 import java.util.regex.Pattern
 import java.util.{ Collections, NoSuchElementException }
@@ -289,9 +289,9 @@ object DepositHandler {
     }
 
     def extract(file: File, outputPath: String): Unit = {
-      new ZipFile(file.getPath) {
-        setFileNameCharset(StandardCharsets.UTF_8.name)
-      }.extractAll(outputPath)
+      val f = better.files.File(file.getAbsolutePath)
+      implicit val charset: Charset = StandardCharsets.UTF_8
+      f unzipTo better.files.File(outputPath)
     }
 
     def getSequenceNumber(f: File): Int = {


### PR DESCRIPTION
Fixes EASY-2082

- [x] Test on `deasy`
   - [x] With files that have non-ASCII file names

#### When applied it will
* Use better.files instead of zip4j to extract the deposit

#### Where should the reviewer @DANS-KNAW/easy start?

