### PR TITLE
EASY-2173: 'origin' kolom voor deposit report

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -171,7 +171,7 @@ object DepositHandler extends BagValidationExtension {
       props <- DepositProperties(id)
       _ <- props.setState(SUBMITTED, "Deposit is valid and ready for post-submission processing")
       _ <- props.setBagName(bagDir)
-      _ <- props.setDepositSource("SWORD2")
+      _ <- props.setDepositOrigin("SWORD2")
       _ <- props.save()
       _ <- SampleTestData.sampleData(id, depositDir, props)(settings.sample)
       _ <- removeZipFiles(depositDir)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -171,6 +171,7 @@ object DepositHandler extends BagValidationExtension {
       props <- DepositProperties(id)
       _ <- props.setState(SUBMITTED, "Deposit is valid and ready for post-submission processing")
       _ <- props.setBagName(bagDir)
+      _ <- props.setDepositSource("SWORD2")
       _ <- props.save()
       _ <- SampleTestData.sampleData(id, depositDir, props)(settings.sample)
       _ <- removeZipFiles(depositDir)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -84,6 +84,11 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
     this
   }
 
+  def setDepositSource(source: String): Try[DepositProperties] = Try {
+    properties.setProperty("deposit.source", source)
+    this
+  }
+
   /**
    * Returns the state when the properties were loaded.
    *

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -84,8 +84,8 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
     this
   }
 
-  def setDepositSource(source: String): Try[DepositProperties] = Try {
-    properties.setProperty("deposit.source", source)
+  def setDepositOrigin(origin: String): Try[DepositProperties] = Try {
+    properties.setProperty("deposit.origin", origin)
     this
   }
 


### PR DESCRIPTION
Fixes EASY-2173

#### When applied it will
* add new property `deposit.source` to deposit properties
* gives this property value `SWORD2`


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-manage-deposit                      | [PR#54](https://github.com/DANS-KNAW/easy-manage-deposit/pull/54)     | ..
easy-split-multi-deposit                      | [PR#138](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/138)     | ..
easy-deposit-api                      | [PR#166](https://github.com/DANS-KNAW/easy-deposit-api/pull/166)     | ..
easy-specs                     | [PR#82](https://github.com/DANS-KNAW/easy-specs/pull/82)     | ..
