### PR TITLE
set the 'deposit.origin' property during creation of the deposit.properties file

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -22,7 +22,6 @@ import java.nio.file._
 import java.util.regex.Pattern
 import java.util.{ Collections, NoSuchElementException }
 
-import better.files.File
 import gov.loc.repository.bagit.FetchTxt.FilenameSizeUrl
 import gov.loc.repository.bagit.transformer.impl.TagManifestCompleter
 import gov.loc.repository.bagit.utilities.SimpleResult
@@ -171,7 +170,6 @@ object DepositHandler extends BagValidationExtension {
       props <- DepositProperties(id)
       _ <- props.setState(SUBMITTED, "Deposit is valid and ready for post-submission processing")
       _ <- props.setBagName(bagDir)
-      _ <- props.setDepositOrigin("SWORD2")
       _ <- props.save()
       _ <- SampleTestData.sampleData(id, depositDir, props)(settings.sample)
       _ <- removeZipFiles(depositDir)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -19,6 +19,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
 
+import nl.knaw.dans.easy.sword2.DepositProperties._
 import nl.knaw.dans.easy.sword2.State.State
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.configuration.PropertiesConfiguration
@@ -37,8 +38,6 @@ import scala.util.{ Failure, Success, Try }
  */
 class DepositProperties(depositId: DepositId, depositorId: Option[String] = None)(implicit settings: Settings) extends DebugEnhancedLogging {
 
-  import DepositProperties._
-
   trace(depositId, depositorId)
 
   private val (properties, modified) = {
@@ -54,6 +53,7 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
     else {
       props.setProperty("bag-store.bag-id", depositId)
       props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
+      props.setProperty("deposit.origin", "SWORD2")
     }
     debug(s"Using deposit.properties at $file")
     depositorId.foreach(props.setProperty("depositor.userId", _))
@@ -81,11 +81,6 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
 
   def setBagName(bagDir: File): Try[DepositProperties] = Try {
     properties.setProperty("bag-store.bag-name", bagDir.getName)
-    this
-  }
-
-  def setDepositOrigin(origin: String): Try[DepositProperties] = Try {
-    properties.setProperty("deposit.origin", origin)
     this
   }
 


### PR DESCRIPTION
~Fixes EASY-~

#### When applied it will
* set the `deposit.origin` property at an earlier time. Currently it does not set this property when a continued deposit is halted before it is completed. That is what mainly changed with this PR. Now the property is set when the `deposit.properties` file is first created.

@DANS-KNAW/easy for review