### PR TITLE
EASY-2339 easy-sword2: mutations are performed both in deposit.properties and in easy-deposit-properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-native_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-ext_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalaj</groupId>
+            <artifactId>scalaj-http_2.12</artifactId>
+        </dependency>
+        <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>easy-sword2-lib</artifactId>
             <version>1.1.1</version>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -23,6 +23,18 @@ cleanup.INVALID=no
 cleanup.REJECTED=no
 cleanup.FAILED=no
 
+#
+# The URL of the deposit properties service.
+#
+easy-deposit-properties.url=http://localhost:20200/
+
+# Where to store deposit properties.
+#
+# FILE: use only the legacy deposit.properties file
+# SERVICE: use only the easy-deposit-properties service
+# BOTH: use both of the above
+easy-deposit-properties.mode=FILE
+
 # To be phased out.
 bag-store.base-url=
 bag-store.base-dir=

--- a/src/main/scala/Test.scala
+++ b/src/main/scala/Test.scala
@@ -1,0 +1,22 @@
+import java.net.URI
+
+import nl.knaw.dans.easy.sword2.{ DepositPropertiesService, GraphQlClient }
+import scalaj.http.{ BaseHttp, Http }
+
+object Test extends App {
+
+  implicit val baseHttp: BaseHttp = Http
+  implicit val depositPropertiesClient: GraphQlClient =
+    new GraphQlClient(
+      url = new URI("http://deasy.dans.knaw.nl:20200/graphql"),
+      credentials = Option((
+        "easy-deposit-properties",
+        "easy_deposit_properties"))
+    )
+
+  val dp = new DepositPropertiesService("85a705ac-f4cd-11e9-8300-9f38b2e04e7d")
+
+
+
+
+}

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
@@ -84,6 +84,7 @@ class ApplicationWiring(configuration: Configuration) extends DebugEnhancedLoggi
     .map(state => state -> Try(configuration.properties.getBoolean(s"cleanup.$state")))
     .collect { case (key, Success(cleanupSetting)) => key -> cleanupSetting }
     .toMap
+  val depositPropertiesUrl: URI = new URI(configuration.properties.getString("easy-deposit-properties.url"))
 
   val rescheduleDelaySeconds: Int = configuration.properties.getInt("reschedule-delay-seconds")
   val version = configuration.version

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
@@ -20,6 +20,7 @@ import java.net.URI
 import java.util.regex.Pattern
 
 import javax.servlet.ServletException
+import nl.knaw.dans.easy.sword2.DepositPropertiesMode.DepositPropertiesMode
 import nl.knaw.dans.easy.sword2.State.State
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.lib.string.StringExtensions
@@ -85,6 +86,9 @@ class ApplicationWiring(configuration: Configuration) extends DebugEnhancedLoggi
     .collect { case (key, Success(cleanupSetting)) => key -> cleanupSetting }
     .toMap
   val depositPropertiesUrl: URI = new URI(configuration.properties.getString("easy-deposit-properties.url"))
+  val depositPropertiesMode: DepositPropertiesMode = DepositPropertiesMode
+    .fromString(configuration.properties.getString("easy-deposit-properties.mode"))
+    .getOrElse(DepositPropertiesMode.FILE)
 
   val rescheduleDelaySeconds: Int = configuration.properties.getInt("reschedule-delay-seconds")
   val version = configuration.version

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositPropertiesFile.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositPropertiesFile.scala
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.sword2
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+
+import nl.knaw.dans.easy.sword2.DepositProperties.{ CLIENT_MESSAGE_CONTENT_TYPE_KEY, CLIENT_MESSAGE_CONTENT_TYPE_KEY_OLD, FILENAME }
+import nl.knaw.dans.easy.sword2.State.State
+import nl.knaw.dans.easy.sword2.{ DepositId, DepositProperties, Settings, State, dateTimeFormatter }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.apache.commons.lang.StringUtils
+import org.joda.time.{ DateTime, DateTimeZone }
+
+import scala.util.{ Failure, Success, Try }
+
+class DepositPropertiesFile(depositId: DepositId, depositorId: Option[String] = None)(implicit settings: Settings) extends DepositProperties with DebugEnhancedLogging {
+
+  trace(depositId, depositorId)
+
+  private val (properties, modified) = {
+    val props = new PropertiesConfiguration()
+    props.setDelimiterParsingDisabled(true)
+    val depositInTemp = settings.tempDir.toPath.resolve(depositId)
+    val depositInInbox = settings.depositRootDir.toPath.resolve(depositId)
+    val file = if (Files.exists(depositInTemp)) depositInTemp.resolve(FILENAME)
+               else if (Files.exists(depositInInbox)) depositInInbox.resolve(FILENAME)
+               else depositInTemp.resolve(FILENAME)
+    props.setFile(file.toFile)
+    if (Files.exists(file)) props.load(file.toFile)
+    else {
+      props.setProperty("bag-store.bag-id", depositId)
+      props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
+      props.setProperty("deposit.origin", "SWORD2")
+    }
+    debug(s"Using deposit.properties at $file")
+    depositorId.foreach(props.setProperty("depositor.userId", _))
+    (props, if (Files.exists(file)) Some(Files.getLastModifiedTime(file))
+            else None)
+  }
+
+  /**
+   * Saves the deposit file to disk.
+   *
+   * @return
+   */
+  def save(): Try[Unit] = Try {
+    debug("Saving deposit.properties")
+    properties.save()
+  }
+
+  def exists: Boolean = properties.getFile.exists
+
+  def setState(state: State, descr: String): Try[DepositProperties] = Try {
+    properties.setProperty("state.label", state)
+    properties.setProperty("state.description", descr)
+    this
+  }
+
+  def setBagName(bagDir: File): Try[DepositProperties] = Try {
+    properties.setProperty("bag-store.bag-name", bagDir.getName)
+    this
+  }
+
+  /**
+   * Returns the state when the properties were loaded.
+   *
+   * @return
+   */
+  def getState: Try[State] = {
+    Option(properties.getProperty("state.label"))
+      .map(_.toString)
+      .map(State.withName)
+      .map(Success(_))
+      .getOrElse(Failure(new IllegalStateException("Deposit without state")))
+  }
+
+  def setClientMessageContentType(contentType: String): Try[DepositProperties] = Try {
+    properties.setProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY, contentType)
+    this
+  }
+
+  def removeClientMessageContentType(): Try[DepositProperties] = Try {
+    properties.clearProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY)
+    properties.clearProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY_OLD) // Also clean up old contentType property if still found
+    this
+  }
+
+  def getClientMessageContentType: Try[String] = {
+    Seq(properties.getString(CLIENT_MESSAGE_CONTENT_TYPE_KEY),
+      properties.getString(CLIENT_MESSAGE_CONTENT_TYPE_KEY_OLD)) // Also look for old contentType to support pre-upgrade deposits
+      .find(StringUtils.isNotBlank)
+      .map(Success(_))
+      .getOrElse(
+        Failure(new IllegalStateException(s"Deposit without $CLIENT_MESSAGE_CONTENT_TYPE_KEY")))
+  }
+
+  /**
+   * Returns the state description when the properties were loaded.
+   *
+   * @return
+   */
+  def getStateDescription: Try[String] = {
+    Option(properties.getProperty("state.description"))
+      .map(_.toString)
+      .map(Success(_))
+      .getOrElse(Failure(new IllegalStateException("Deposit without state")))
+  }
+
+  def getDepositorId: Try[String] = {
+    Option(properties.getProperty("depositor.userId"))
+      .map(_.toString)
+      .map(Success(_))
+      .getOrElse(Failure(new IllegalStateException("Deposit without depositor")))
+  }
+
+  def getDoi: Option[String] = {
+    Option(properties.getProperty("identifier.doi"))
+      .map(_.toString)
+  }
+
+  /**
+   * Returns the last modified timestamp when the properties were loaded.
+   *
+   * @return
+   */
+  def getLastModifiedTimestamp: Option[FileTime] = {
+    modified
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositPropertiesMode.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositPropertiesMode.scala
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.sword2
+
+object DepositPropertiesMode extends Enumeration {
+  type DepositPropertiesMode = Value
+  val FILE, SERVICE, BOTH = Value
+  def fromString(s: String): Option[DepositPropertiesMode] = values.find(_.toString == s)
+}

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositPropertiesService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositPropertiesService.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.sword2
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+
+import nl.knaw.dans.easy.sword2.DepositProperties.FILENAME
+import nl.knaw.dans.easy.sword2.State.State
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.apache.commons.configuration.PropertiesConfiguration
+import org.joda.time.{ DateTime, DateTimeZone }
+
+import scala.util.Try
+
+class DepositPropertiesService(depositId: DepositId, depositorId: Option[String] = None)(implicit settings: Settings) extends DepositProperties with DebugEnhancedLogging {
+  trace(depositId, depositorId)
+
+  private val (properties, modified) = {
+    val props = new PropertiesConfiguration()
+    props.setDelimiterParsingDisabled(true)
+    val depositInTemp = settings.tempDir.toPath.resolve(depositId)
+    val depositInInbox = settings.depositRootDir.toPath.resolve(depositId)
+    val file = if (Files.exists(depositInTemp)) depositInTemp.resolve(FILENAME)
+               else if (Files.exists(depositInInbox)) depositInInbox.resolve(FILENAME)
+               else depositInTemp.resolve(FILENAME)
+    props.setFile(file.toFile)
+    if (Files.exists(file)) props.load(file.toFile)
+    else {
+      props.setProperty("bag-store.bag-id", depositId)
+      props.setProperty("creation.timestamp", DateTime.now(DateTimeZone.UTC).toString(dateTimeFormatter))
+      props.setProperty("deposit.origin", "SWORD2")
+    }
+    debug(s"Using deposit.properties at $file")
+    depositorId.foreach(props.setProperty("depositor.userId", _))
+    (props, if (Files.exists(file)) Some(Files.getLastModifiedTime(file))
+            else None)
+  }
+
+
+
+
+  override def save(): Try[Unit] = ???
+
+  override def exists: Boolean = ???
+
+  override def setState(state: State, descr: String): Try[DepositProperties] = ???
+
+  override def setBagName(bagDir: File): Try[DepositProperties] = ???
+
+  override def getState: Try[State] = ???
+
+  override def setClientMessageContentType(contentType: String): Try[DepositProperties] = ???
+
+  override def removeClientMessageContentType(): Try[DepositProperties] = ???
+
+  override def getClientMessageContentType: Try[String] = ???
+
+  override def getStateDescription: Try[String] = ???
+
+  override def getDepositorId: Try[String] = ???
+
+  override def getDoi: Option[String] = ???
+
+  override def getLastModifiedTimestamp: Option[FileTime] = ???
+}

--- a/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
@@ -43,7 +43,7 @@ class EasySword2Service(val serverPort: Int, app: EasySword2App) extends DebugEn
     sample = app.wiring.sampleSettings,
     cleanup = app.wiring.cleanup,
     rescheduleDelaySeconds = app.wiring.rescheduleDelaySeconds,
-    depositPropertiesUrl = app.wiring.depositPropertiesUrl,
+    depositPropertiesClient = app.wiring.depositPropertiesClient,
     depositPropertiesMode = app.wiring.depositPropertiesMode
   )
   context.setAttribute(servlets.EASY_SWORD2_SETTINGS_ATTRIBUTE_KEY, settings)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
@@ -43,7 +43,8 @@ class EasySword2Service(val serverPort: Int, app: EasySword2App) extends DebugEn
     sample = app.wiring.sampleSettings,
     cleanup = app.wiring.cleanup,
     rescheduleDelaySeconds = app.wiring.rescheduleDelaySeconds,
-    depositPropertiesUrl = app.wiring.depositPropertiesUrl
+    depositPropertiesUrl = app.wiring.depositPropertiesUrl,
+    depositPropertiesMode = app.wiring.depositPropertiesMode
   )
   context.setAttribute(servlets.EASY_SWORD2_SETTINGS_ATTRIBUTE_KEY, settings)
   /*

--- a/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
@@ -42,7 +42,8 @@ class EasySword2Service(val serverPort: Int, app: EasySword2App) extends DebugEn
     marginDiskSpace = app.wiring.marginDiskSpace,
     sample = app.wiring.sampleSettings,
     cleanup = app.wiring.cleanup,
-    rescheduleDelaySeconds = app.wiring.rescheduleDelaySeconds
+    rescheduleDelaySeconds = app.wiring.rescheduleDelaySeconds,
+    depositPropertiesUrl = app.wiring.depositPropertiesUrl
   )
   context.setAttribute(servlets.EASY_SWORD2_SETTINGS_ATTRIBUTE_KEY, settings)
   /*

--- a/src/main/scala/nl.knaw.dans.easy.sword2/GraphQlClient.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/GraphQlClient.scala
@@ -1,0 +1,70 @@
+package nl.knaw.dans.easy.sword2
+
+import java.net.URI
+
+import org.json4s.JsonAST.{ JArray, JString }
+import org.json4s.JsonDSL._
+import org.json4s.native.{ JsonMethods, Serialization }
+import org.json4s.{ DefaultFormats, Formats, JValue }
+import scalaj.http.BaseHttp
+
+/**
+ * A client wrapping both the logic of executing a GraphQL query on a particular URL and
+ * parsing the response.
+ *
+ * @param url         the URL of the GraphQL server on which the query is executed
+ * @param credentials the credentials (if required) required to execute the query
+ * @param http        the ''BaseHttp'' object required for sending the request
+ * @param jsonFormats the formatter used for parsing and generating the JSON
+ */
+class GraphQlClient(url: URI, credentials: Option[(String, String)] = Option.empty)(implicit http: BaseHttp, jsonFormats: Formats = new DefaultFormats {}) {
+
+  /**
+   * Execute a GraphQL query, if provided sent together with the variables. The response is parsed
+   * into either a sequence of errors (if ''errors'' is present in the response) or the JSON inside
+   * the ''data'' object.
+   *
+   * @param query     the query to be executed
+   * @param variables values for the placeholders in the query
+   * @param ev        evidence that the values in the variables mapping can be converted to JSON
+   * @tparam A the values in the variables mapping
+   * @return the JSON object inside ''data'' if the query was successful;
+   *         a list of error messages otherwise
+   */
+  def doQuery[A](query: String, variables: Map[String, A] = Map.empty)(implicit ev: A => JValue): Either[Seq[String], JValue] = {
+    val baseHttp = http(url.toString)
+      .headers(
+        "Accept" -> "application/json",
+        "Content-Type" -> "application/json",
+      )
+      .postData(Serialization.write {
+        val q = "query" -> query
+
+        if (variables.nonEmpty) q ~ ("variables" -> variables)
+        else q
+      })
+
+    val body = credentials.fold(baseHttp) {
+      case (username, password) => baseHttp.auth(username, password)
+    }.asString.body
+    val json = JsonMethods.parse(body)
+
+    parseErrors(json \ "errors")
+      .map(Left(_))
+      .getOrElse(Right(json \ "data"))
+  }
+
+  // following https://graphql.github.io/graphql-spec/June2018/#sec-Response-Format
+  private def parseErrors(errors: JValue): Option[List[String]] = {
+    errors match {
+      case JArray(Nil) => Option.empty
+      case JArray(es) => Option {
+        es.map(error => {
+          val JString(msg) = error \ "message"
+          msg
+        })
+      }
+      case _ => Option.empty
+    }
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -21,6 +21,7 @@ import java.util.regex.Pattern
 
 import nl.knaw.dans.easy.sword2.DepositHandler.log
 import nl.knaw.dans.easy.sword2.State.State
+import nl.knaw.dans.easy.sword2.DepositPropertiesMode._
 import org.joda.time.format.{ DateTimeFormatter, ISODateTimeFormat }
 import org.swordapp.server.DepositReceipt
 
@@ -54,7 +55,8 @@ package object sword2 {
                       sample: SampleTestDataSettings,
                       cleanup: Map[State, Boolean],
                       rescheduleDelaySeconds: Int,
-                      depositPropertiesUrl: URI)
+                      depositPropertiesUrl: URI,
+                      depositPropertiesMode: DepositPropertiesMode)
 
 
   case class BagStoreSettings(baseDir: String, baseUrl: String)

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -53,8 +53,9 @@ package object sword2 {
                       marginDiskSpace: Long,
                       sample: SampleTestDataSettings,
                       cleanup: Map[State, Boolean],
-                      rescheduleDelaySeconds: Int
-                     )
+                      rescheduleDelaySeconds: Int,
+                      depositPropertiesUrl: URI)
+
 
   case class BagStoreSettings(baseDir: String, baseUrl: String)
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -55,7 +55,7 @@ package object sword2 {
                       sample: SampleTestDataSettings,
                       cleanup: Map[State, Boolean],
                       rescheduleDelaySeconds: Int,
-                      depositPropertiesUrl: URI,
+                      depositPropertiesClient: GraphQlClient,
                       depositPropertiesMode: DepositPropertiesMode)
 
 

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -27,3 +27,16 @@ auth.single.password=
 cleanup.INVALID=no
 cleanup.REJECTED=no
 cleanup.FAILED=no
+
+
+#
+# The URL of the deposit properties service.
+#
+easy-deposit-properties.url=http://localhost:20200/
+
+# Where to store deposit properties.
+#
+# FILE: use only the legacy deposit.properties file
+# SERVICE: use only the easy-deposit-properties service
+# BOTH: use both of the above
+easy-deposit-properties.mode=FILE

--- a/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
@@ -44,7 +44,8 @@ class AuthenticationSpec extends FlatSpec with Matchers with MockFactory with On
     marginDiskSpace = 0,
     sample = SampleTestDataEnabled(new File("sample-dummy"), Map.empty),
     cleanup = Map.empty,
-    rescheduleDelaySeconds = 0
+    rescheduleDelaySeconds = 0,
+    depositPropertiesUrl = null
   )
 
   private val ldapContext = mock[LdapContext]

--- a/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
@@ -45,7 +45,7 @@ class AuthenticationSpec extends FlatSpec with Matchers with MockFactory with On
     sample = SampleTestDataEnabled(new File("sample-dummy"), Map.empty),
     cleanup = Map.empty,
     rescheduleDelaySeconds = 0,
-    depositPropertiesUrl = null,
+    depositPropertiesClient = null,
     depositPropertiesMode = DepositPropertiesMode.FILE
   )
 

--- a/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
@@ -45,7 +45,8 @@ class AuthenticationSpec extends FlatSpec with Matchers with MockFactory with On
     sample = SampleTestDataEnabled(new File("sample-dummy"), Map.empty),
     cleanup = Map.empty,
     rescheduleDelaySeconds = 0,
-    depositPropertiesUrl = null
+    depositPropertiesUrl = null,
+    depositPropertiesMode = DepositPropertiesMode.FILE
   )
 
   private val ldapContext = mock[LdapContext]

--- a/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
@@ -44,7 +44,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues {
         9090000L,
         null,
         Map(),
-        90000)
+        90000,
+        null)
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
@@ -45,7 +45,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues {
         null,
         Map(),
         90000,
-        null)
+        null,
+        DepositPropertiesMode.FILE)
     }
   }
 }


### PR DESCRIPTION
Fixes EASY-2339

**This is a DRAFT PR**

- [ ] Find out which properties cannot be saved to `easy-deposit-properties`.
- [ ] Implement `nl.knaw.dans.easy.sword2.DepositPropertiesService`.
- [ ] Add unit tests.
- [ ] Implement `DepositPropertiesBoth`.
- [ ] Let choice of `DepositProperties` implementation depend on application setting.

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

