### PR TITLE
EASY-2511: make easy-ingest-flow-inbox-archived available for search of deposits in easy-sword2

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -1,5 +1,6 @@
 daemon.http.port=20100
-deposits.rootdir=/var/opt/dans.knaw.nl/spool/sword2-deposits
+deposits.rootdir=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
+deposits.archived-rootdir=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox-archived
 deposits.permissions=rwxrwx---
 sample-data.dir=/var/opt/dans.knaw.nl/tmp/sword2-sample-input
 sample-data.enabled=false

--- a/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/ApplicationWiring.scala
@@ -30,6 +30,7 @@ import scala.util.{ Success, Try }
 class ApplicationWiring(configuration: Configuration) extends DebugEnhancedLogging {
   val depositRootDir = new File(configuration.properties.getString("deposits.rootdir"))
   if (!depositRootDir.canRead) throw new ServletException("Cannot read deposits dir")
+  val archivedDepositRootDir: Option[File] = Option(configuration.properties.getString("deposits.archived-rootdir")).map(new File(_)).filter(d => d.exists() && d.canRead)
   val depositPermissions = configuration.properties.getString("deposits.permissions")
   val tempDir = new File(configuration.properties.getString("tempdir"))
   if (!tempDir.canRead) throw new ServletException("Cannot read tempdir")

--- a/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/EasySword2Service.scala
@@ -31,6 +31,7 @@ class EasySword2Service(val serverPort: Int, app: EasySword2App) extends DebugEn
   // TODO: Refactor this so that we do not need access to the application's wiring from outside the object.
   val settings = Settings(
     depositRootDir = app.wiring.depositRootDir,
+    archivedDepositRootDir = app.wiring.archivedDepositRootDir,
     depositPermissions = app.wiring.depositPermissions,
     tempDir = app.wiring.tempDir,
     serviceBaseUrl = app.wiring.baseUrl,

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -42,6 +42,7 @@ package object sword2 {
   case object SampleTestDataDisabled extends SampleTestDataSettings
 
   case class Settings(depositRootDir: File,
+                      archivedDepositRootDir: Option[File],
                       depositPermissions: String,
                       tempDir: File,
                       serviceBaseUrl: String, // TODO: refactor to URL?

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -1,5 +1,6 @@
 daemon.http.port=20100
 deposits.rootdir=data/deposits
+deposits.archived-rootdir=data/deposits-archived
 deposits.permissions=rwxrwx---
 sample-data.dir=data/sword2-test-input
 sample-data.enabled=true

--- a/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
@@ -33,6 +33,7 @@ import scala.util.{ Failure, Success, Try }
 class AuthenticationSpec extends FlatSpec with Matchers with MockFactory with OneInstancePerTest {
   implicit val settings: Settings = Settings(
     depositRootDir = new File("dummy"),
+    archivedDepositRootDir = Option(new File("dummy")),
     depositPermissions = "dummy",
     tempDir = new File("dummy"),
     serviceBaseUrl = "dummy",

--- a/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
@@ -33,6 +33,7 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues {
   def createMinimalSettings(bag: File): SwordConfig = {
     new SwordConfig {
       settings = Settings(depositRootDir = bag.toJava,
+        archivedDepositRootDir = Option.empty,
         "rwxrwxrwx",
         new java.io.File("dummy"),
         "",
@@ -44,7 +45,8 @@ trait TestSupportFixture extends FlatSpec with Matchers with OptionValues {
         9090000L,
         null,
         Map(),
-        90000)
+        90000,
+      )
     }
   }
 }


### PR DESCRIPTION
Fixes EASY-2511

#### When applied it will
* make easy-ingest-flow-inbox-archived available for search of deposits in `easy-sword2`

#### How should this be manually tested?
* checkout this PR as well as the related PR in `easy-dtap`
* build and deploy this PR on `deasy`
* use `easy-sword2-dans-examples` to upload a deposit to `deasy` and wait for the processing to finish
* request the status (should be archived) of the deposit
* in `deasy`, move the deposit from `easy-ingest-flow-inbox` to `easy-ingest-flow-inbox-archived`
* request the status again. `easy-sword2` should find the deposit in its new location

@DANS-KNAW/easy for review

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-dtap | [PR#432](https://github.com/DANS-KNAW/easy-dtap/pull/432)     | configuration
