### PR TITLE
EASY-2474 Convert documentation to mkdocs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GH_ORG=DANS-KNAW
+
+set -e
+
+# Relies on Travis checking out repo to a dir with the repo's name.
+GH_REPO=$(basename $TRAVIS_BUILD_DIR)
+REMOTE="https://${GH_TOKEN}@github.com/${GH_ORG}/${GH_REPO}"
+git remote set-url origin ${REMOTE}
+
+echo "START installing required Python packages..."
+pip3 install mkdocs
+pip3 install pygments
+pip3 install pymdown-extensions
+pip3 install pyyaml
+pip3 install mkdocs-markdownextradata-plugin
+echo "DONE installing required Python packages."
+
+echo "START installing DANS mkdocs theme..."
+git clone https://github.com/Dans-labs/mkdocs-dans $HOME/mkdocs-dans
+pushd $HOME/mkdocs-dans
+git pull
+python3 build.py pack
+popd
+echo "DONE installing DANS mkdocs theme."
+
+echo "START deploying docs to GitHub pages..."
+mkdocs gh-deploy --force
+echo "DONE deploying docs to GitHub pages."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
-language: java
-jdk: openjdk8
-cache:
-  directories:
-  - "$HOME/.m2/repository"
+matrix:
+  include:
+    - language: java
+      jdk: openjdk8
+      cache:
+        directories:
+          - "$HOME/.m2/repository"
+    - language: python
+      if: branch = master AND NOT type = pull_request
+      python: 3.7.1
+      cache:
+        directories:
+          - "$HOME/.cache"
+          - "$HOME/virtualenv"
+      script:
+        - "./.travis.sh"

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ EASY SWORD v2 Deposit Service.
 Welcome
 -------
 
-Welcome to the `easy-sword2` project. See the [GitHub pages](https://dans-knaw.github.io/easy-sword2/) for the manual and API documentation.
+Welcome to the `easy-sword2` project. See the [GitHub pages](https://dans-knaw.github.io/easy-sword2/) for the manual and the [SWORD2 documentation pages](http://swordapp.org/sword-v2/sword-v2-specifications/
+) for documentation of the HTTP interface.

--- a/README.md
+++ b/README.md
@@ -2,60 +2,10 @@ easy-sword2
 ===========
 [![Build Status](https://travis-ci.org/DANS-KNAW/easy-sword2.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-sword2)
 
-SYNOPSIS
---------
-
-    easy-sword2 run-service
+EASY SWORD v2 Deposit Service.
 
 
-DESCRIPTION
------------
+Welcome
+-------
 
-EASY SWORD v2 Deposit Service
-
-
-ARGUMENTS
----------
-
-    Options:
-
-      -h, --help      Show help message
-      -v, --version   Show version of this program
-
-    Subcommand: run-service - Starts EASY SWORD v2 as a daemon that services HTTP requests
-       -h, --help   Show help message
-    ---
-
-
-INSTALLATION AND CONFIGURATION
-------------------------------
-Currently this project is built as an RPM package for RHEL7/CentOS7 and later. The RPM will install the binaries to
-`/opt/dans.knaw.nl/easy-sword2` and the configuration files to `/etc/opt/dans.knaw.nl/easy-sword2`. 
-
-To install the module on systems that do not support RPM, you can copy and unarchive the tarball to the target host.
-You will have to take care of placing the files in the correct locations for your system yourself. For instructions
-on building the tarball, see next section.
-
-
-BUILDING FROM SOURCE
---------------------
-
-Prerequisites:
-
-* Java 8 or higher
-* Maven 3.3.3 or higher
-* RPM
-
-Steps:
-
-        git clone https://github.com/DANS-KNAW/easy-sword2.git
-        cd easy-sword2
-        mvn install
-
-If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM 
-packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
-Maven's `-P` switch: `mvn -Pprm install`.
-
-Alternatively, to build the tarball execute:
-
-    mvn clean install assembly:single
+Welcome to the `easy-sword2` project. See the [GitHub pages](https://dans-knaw.github.io/easy-sword2/) for the manual and API documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+easy-sword2
+===========
+[![Build Status](https://travis-ci.org/DANS-KNAW/easy-sword2.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-sword2)
+
+SYNOPSIS
+--------
+
+    easy-sword2 run-service
+
+
+DESCRIPTION
+-----------
+
+EASY SWORD v2 Deposit Service
+
+
+ARGUMENTS
+---------
+
+    Options:
+
+      -h, --help      Show help message
+      -v, --version   Show version of this program
+
+    Subcommand: run-service - Starts EASY SWORD v2 as a daemon that services HTTP requests
+       -h, --help   Show help message
+    ---
+
+
+INSTALLATION AND CONFIGURATION
+------------------------------
+Currently this project is built as an RPM package for RHEL7/CentOS7 and later. The RPM will install the binaries to
+`/opt/dans.knaw.nl/easy-sword2` and the configuration files to `/etc/opt/dans.knaw.nl/easy-sword2`. 
+
+To install the module on systems that do not support RPM, you can copy and unarchive the tarball to the target host.
+You will have to take care of placing the files in the correct locations for your system yourself. For instructions
+on building the tarball, see next section.
+
+
+BUILDING FROM SOURCE
+--------------------
+
+Prerequisites:
+
+* Java 8 or higher
+* Maven 3.3.3 or higher
+* RPM
+
+Steps:
+
+        git clone https://github.com/DANS-KNAW/easy-sword2.git
+        cd easy-sword2
+        mvn install
+
+If the `rpm` executable is found at `/usr/local/bin/rpm`, the build profile that includes the RPM 
+packaging will be activated. If `rpm` is available, but at a different path, then activate it by using
+Maven's `-P` switch: `mvn -Pprm install`.
+
+Alternatively, to build the tarball execute:
+
+    mvn clean install assembly:single

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,10 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-EASY SWORD v2 Deposit Service
+EASY SWORD v2 Deposit Service.
+
+See the [SWORD2 documentation pages](http://swordapp.org/sword-v2/sword-v2-specifications/
+) for documentation of the HTTP interface.
 
 
 ARGUMENTS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+site_name: easy-sword2
+theme:
+  name: dans
+  disclaimer: false
+
+repo_name: DANS-KNAW/easy-sword2
+repo_url: https://github.com/DANS-KNAW/easy-sword2
+
+nav:
+  - Manual: index.md
+
+plugins:
+  - markdownextradata
+  - search
+
+markdown_extensions:
+  - attr_list
+  #- legacy_attr
+  - admonition
+  - codehilite:
+      guess_lang: false
+  - def_list
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: Dans-labs
+      repo: mkdocs-dans
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde

--- a/src/test/scala/nl.knaw.dans.easy.sword2/ReadmeSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/ReadmeSpec.scala
@@ -34,19 +34,19 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
     mockedStdOut.toString
   }
 
-  "options in help info" should "be part of README.md" in {
+  "options in help info" should "be part of docs/index.md" in {
     val lineSeparators = s"(${ System.lineSeparator() })+"
     val options = helpInfo.split(s"${ lineSeparators }Options:$lineSeparators")(1)
     options.trim.length shouldNot be(0)
-    new File("README.md") should containTrimmed(options)
+    new File("docs/index.md") should containTrimmed(options)
   }
 
-  "synopsis in help info" should "be part of README.md" in {
-    new File("README.md") should containTrimmed(clo.synopsis)
+  "synopsis in help info" should "be part of docs/index.md" in {
+    new File("docs/index.md") should containTrimmed(clo.synopsis)
   }
 
-  "description line(s) in help info" should "be part of README.md and pom.xml" in {
-    new File("README.md") should containTrimmed(clo.description)
+  "description line(s) in help info" should "be part of docs/index.md and pom.xml" in {
+    new File("docs/index.md") should containTrimmed(clo.description)
     new File("pom.xml") should containTrimmed(clo.description)
   }
 }


### PR DESCRIPTION
fixes EASY-2474

#### When applied it will
* convert the project documentation to mkdocs format

#### Where should the reviewer @DANS-KNAW/easy start?
check out the project, run `mkdocs serve`

#### How should this be manually tested?
https://dans-labs.github.io/mkdocs-dans/