### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
+            <version>4.12.3</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -115,7 +114,6 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>4.11.0</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
     <inceptionYear>2015</inceptionYear>
     <properties>
         <main-class>nl.knaw.dans.easy.sword2.Command</main-class>
+        <easy.sword2-lib.version>1.1.1</easy.sword2-lib.version>
+        <bagit.version>4.12.3</bagit.version>
     </properties>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
@@ -86,7 +88,7 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>easy-sword2-lib</artifactId>
-            <version>1.1.1</version>
+            <version>${easy.sword2-lib.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>
@@ -113,7 +115,7 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>4.12.3</version>
+            <version>${bagit.version}</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.sword2/Authentication.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Authentication.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.sword2
 
 import java.net.URI
 import java.util
+import java.util.Base64
 
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -42,7 +43,7 @@ object Authentication {
     val mac = Mac.getInstance("HmacSHA1")
     mac.init(signingKey)
     val rawHmac = mac.doFinal(password.getBytes())
-    new sun.misc.BASE64Encoder().encode(rawHmac)
+    Base64.getEncoder().encodeToString(rawHmac)
   }
 
   @throws(classOf[SwordError])

--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -28,7 +28,7 @@ import gov.loc.repository.bagit.utilities.SimpleResult
 import gov.loc.repository.bagit.verify.CompleteVerifier
 import gov.loc.repository.bagit.writer.impl.FileSystemWriter
 import gov.loc.repository.bagit.{ Bag, BagFactory, FetchTxt }
-import net.lingala.zip4j.core.ZipFile
+import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.exception.ZipException
 import net.lingala.zip4j.model.FileHeader
 import nl.knaw.dans.easy.sword2.State._

--- a/src/main/scala/nl.knaw.dans.easy.sword2/SampleTestData.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/SampleTestData.scala
@@ -22,7 +22,7 @@ import java.nio.file.{ Files, NoSuchFileException, Path, Paths }
 import java.security.MessageDigest
 import java.util.UUID
 
-import net.lingala.zip4j.core.ZipFile
+import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.model.ZipParameters
 import nl.knaw.dans.easy.sword2.State.State
 import nl.knaw.dans.lib.error._
@@ -109,9 +109,7 @@ object SampleTestData extends DebugEnhancedLogging {
     val extractSampleDir = targetDir.resolve("unzipped")
     debug(s"extracting $zip to $extractSampleDir")
 
-    new ZipFile(zip.toString) {
-      setFileNameCharset(StandardCharsets.UTF_8.name)
-    }.extractAll(extractSampleDir.toString)
+    new ZipFile(zip.toString).extractAll(extractSampleDir.toString)
 
     if (logger.underlying.isDebugEnabled)
       debug(s"extracted $zip into $extractSampleDir: ${ extractSampleDir.toFile.listFilesSafe.mkString("[", ", ", "]") }")
@@ -247,9 +245,7 @@ object SampleTestData extends DebugEnhancedLogging {
 
     Files.deleteIfExists(target)
 
-    val zip = new ZipFile(target.toFile) {
-      setFileNameCharset(StandardCharsets.UTF_8.name)
-    }
+    val zip = new ZipFile(target.toFile)
     zip.addFolder(bag.toFile, new ZipParameters)
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/servlets/EasySword2Servlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/servlets/EasySword2Servlet.scala
@@ -26,6 +26,6 @@ class EasySword2Servlet(version: String) extends ScalatraServlet
 
   get("/") {
     contentType = "text/plain"
-    logResponse(Ok(s"EASY SWORD2 is running v$version."))
+    Ok(s"EASY SWORD2 is running v$version.")
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/servlets/EasySword2Servlet.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/servlets/EasySword2Servlet.scala
@@ -26,6 +26,6 @@ class EasySword2Servlet(version: String) extends ScalatraServlet
 
   get("/") {
     contentType = "text/plain"
-    Ok(s"EASY SWORD2 is running v$version.").logResponse
+    logResponse(Ok(s"EASY SWORD2 is running v$version."))
   }
 }


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* move unique dependency versions that aren't included in a parent POM to properties
* change `lines.toList` to `linesIterator.toList` due to https://github.com/scala/bug/issues/11125
* remove ZipFile setFilenameCharset UTF8, since it is already the default value

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink)