### PR TITLE
EASY-2506. Exclude log4j lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,10 +98,6 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -116,6 +112,12 @@
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
             <version>4.11.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>


### PR DESCRIPTION
Fixes EASY-2506

#### When applied it will
* Completely exclude log4j from the dependencies.
* Remove a redundant exclude.

#### Where should the reviewer @DANS-KNAW/easy start?
The pom.xml

#### How should this be manually tested?
* Build and install `easy-sword2`
* Double-check that the log4j lib is *not* included under `/opt/dans.knaw.nl/easy-sword2/lib`.
* Add the following logger to `/etc/opt/dans.knaw.nl/easy-sword2/logback-service.xml`:
  ```
  <logger name="gov.loc" level="trace" />
  ```
* Do a sword deposit and check that the log contains logging that is apparently done by the 
  `bagit-java` library, for example:
  ```
   [2020-03-16 10:17:53,700] DEBUG Wrote to manifest:  Filename is data/visibilities/known.txt. Fixity is 3f822b34089e1da7a490536e50c15a28c45ab4bb.
   [2020-03-16 10:17:53,700] DEBUG Wrote to manifest:  Filename is data/random/images/image02.jpeg.  Fixity is 4ae4fb20ee161b8026a468160553e623dcea4914.
   [2020-03-16 10:17:53,700] DEBUG Wrote to manifest:  Filename is data/accessibilities/known.txt.  Fixity is f375ad2556c094df000af13f77e40716403fc62f.
   [2020-03-16 10:17:53,700] DEBUG Wrote to manifest:  Filename is data/accessibilities/anonymous.txt.  Fixity is 4f5ea58e1c7e617f2190f7d9cf33637bc14aae02.
  ```

