### PR TITLE
EASY-2484: set the correct UNIX rights after the zip is extracted

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -467,8 +467,7 @@ object DepositHandler extends BagValidationExtension with DebugEnhancedLogging {
 
   def moveBagToStorage(depositDir: JFile, storageDir: JFile)(implicit settings: Settings, id: DepositId): Try[JFile] = {
     debug(s"[$id] Moving bag to permanent storage")
-    FilesPermission.changePermissionsRecursively(depositDir, settings.depositPermissions, id)
-      .map(_ => Files.move(depositDir.toPath.toAbsolutePath, storageDir.toPath.toAbsolutePath).toFile)
+    Try { Files.move(depositDir.toPath.toAbsolutePath, storageDir.toPath.toAbsolutePath).toFile }
       .recoverWith { case e => Failure(new SwordError("Failed to move dataset to storage", e)) }
   }
 


### PR DESCRIPTION
Fixes EASY-2484

#### When applied it will
* set the correct UNIX rights after the zip is extracted

@DANS-KNAW/easy for review