### PR TITLE
EASY-2339: Merge calls to setState and setClientMessageContentType into one call

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositHandler.scala
@@ -136,8 +136,7 @@ object DepositHandler extends DebugEnhancedLogging {
       logger.info(s"[$id] Scheduling deposit to be finalized")
       for {
         props <- DepositProperties.load(id)
-        _ <- props.setState(State.UPLOADED, "Deposit upload has been completed.")
-        _ <- props.setClientMessageContentType(deposit.getMimeType)
+        _ <- props.setStateAndClientMessageContentType(State.UPLOADED, "Deposit upload has been completed.", deposit.getMimeType)
         _ <- props.save()
       } yield DepositProcessor.processDeposit(id, deposit.getMimeType)
     }

--- a/src/main/scala/nl.knaw.dans.easy.sword2/properties/CompoundDepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/properties/CompoundDepositProperties.scala
@@ -67,10 +67,10 @@ class CompoundDepositProperties(file: DepositProperties,
     } yield ()
   }
 
-  override def setClientMessageContentType(contentType: String): Try[Unit] = {
+  override def setStateAndClientMessageContentType(stateLabel: State, stateDescription: String, contentType: String): Try[Unit] = {
     for {
-      _ <- service.setClientMessageContentType(contentType)
-      _ <- file.setClientMessageContentType(contentType)
+      _ <- service.setStateAndClientMessageContentType(stateLabel, stateDescription, contentType)
+      _ <- file.setStateAndClientMessageContentType(stateLabel, stateDescription, contentType)
     } yield ()
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/properties/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/properties/DepositProperties.scala
@@ -36,7 +36,7 @@ trait DepositProperties {
 
   def setBagName(bagName: String): Try[Unit]
 
-  def setClientMessageContentType(contentType: String): Try[Unit]
+  def setStateAndClientMessageContentType(stateLabel: State, stateDescription: String, contentType: String): Try[Unit]
 
   def removeClientMessageContentType(): Try[Unit]
 

--- a/src/main/scala/nl.knaw.dans.easy.sword2/properties/FileDepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/properties/FileDepositProperties.scala
@@ -80,8 +80,9 @@ class FileDepositProperties(properties: PropertiesConfiguration) extends Deposit
     properties.setProperty(BAGSTORE_BAGNAME_KEY, bagName)
   }
 
-  override def setClientMessageContentType(contentType: String): Try[Unit] = Try {
-    properties.setProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY, contentType)
+  override def setStateAndClientMessageContentType(stateLabel: State, stateDescription: String, contentType: String): Try[Unit] = {
+    setState(stateLabel, stateDescription)
+      .map(_ => properties.setProperty(CLIENT_MESSAGE_CONTENT_TYPE_KEY, contentType))
   }
 
   override def removeClientMessageContentType(): Try[Unit] = Try {

--- a/src/main/scala/nl.knaw.dans.easy.sword2/properties/ServiceDepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/properties/ServiceDepositProperties.scala
@@ -73,13 +73,15 @@ class ServiceDepositProperties(depositId: DepositId, client: GraphQLClient)(impl
       .toTry
   }
 
-  override def setClientMessageContentType(contentType: String): Try[Unit] = {
-    val setContentTypeVariables = Map(
+  override def setStateAndClientMessageContentType(stateLabel: State, stateDescription: String, contentType: String): Try[Unit] = {
+    val setStateAndClientMessageContentTypeVariables = Map(
       "depositId" -> depositId,
+      "stateLabel" -> stateLabel.toString,
+      "stateDescription" -> stateDescription,
       "contentType" -> contentType,
     )
 
-    client.doQuery(SetContentType.query, SetContentType.operationName, setContentTypeVariables)
+    client.doQuery(SetContentType.query, SetContentType.operationName, setStateAndClientMessageContentTypeVariables)
       .map(_ => ())
       .toTry
   }
@@ -187,15 +189,22 @@ object ServiceDepositProperties {
   }
 
   object SetContentType {
-    val operationName = "SetContentType"
+    val operationName = "SetStateAndClientMessageContentType"
     val query: String =
-      """mutation SetContentType($depositId: UUID!, $contentType: String!) {
-        |  setContentType(input: { depositId: $depositId, value: $contentType }) {
+      """mutation SetStateAndClientMessageContentType($depositId: UUID!, $stateLabel: StateLabel!, $stateDescription: String!, $contentType: String!) {
+        |  updateState(input: {depositId: $depositId, label: $stateLabel, description: $stateDescription}) {
+        |    state {
+        |      label
+        |      description
+        |    }
+        |  }
+        |  setContentType(input: {depositId: $depositId, value: $contentType}) {
         |    contentType {
         |      value
         |    }
         |  }
-        |}""".stripMargin
+        |}
+        |""".stripMargin
   }
 
   object GetContentType {

--- a/src/test/scala/nl.knaw.dans.easy.sword2/properties/ServiceDepositPropertiesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/properties/ServiceDepositPropertiesSpec.scala
@@ -210,11 +210,17 @@ class ServiceDepositPropertiesSpec extends TestSupportFixture with BeforeAndAfte
     }
   }
 
-  "setClientMessageContentType" should "call the GraphQL service to set the client-message-content-type" in {
+  "setStateAndClientMessageContentType" should "call the GraphQL service to set the client-message-content-type" in {
     val contentType = "application/zip"
     val response =
       """{
         |  "data": {
+        |    "updateState": {
+        |      "state": {
+        |        "label": "UPLOADED",
+        |        "description": "Deposit upload has been completed."
+        |      }
+        |    },
         |    "setContentType": {
         |      "contentType": {
         |        "value": "application/zip"
@@ -224,13 +230,15 @@ class ServiceDepositPropertiesSpec extends TestSupportFixture with BeforeAndAfte
         |}""".stripMargin
     server.enqueue(new MockResponse().setBody(response))
 
-    properties.setClientMessageContentType(contentType) shouldBe a[Success[_]]
+    properties.setStateAndClientMessageContentType(State.UPLOADED, "Deposit upload has been completed.", contentType) shouldBe a[Success[_]]
 
     server.takeRequest().getBody.readUtf8() shouldBe Serialization.write {
       ("query" -> ServiceDepositProperties.SetContentType.query) ~
         ("operationName" -> ServiceDepositProperties.SetContentType.operationName) ~
         ("variables" -> Map(
           "depositId" -> depositId,
+          "stateLabel" -> "UPLOADED",
+          "stateDescription" -> "Deposit upload has been completed.",
           "contentType" -> contentType,
         ))
     }


### PR DESCRIPTION
Fixes EASY-2339

#### When applied it will
* merge calls to setState and setClientMessageContentType into one call
* remove some unused parameters

@DANS-KNAW/easy for review