### PR TITLE
EASY-2739: Add urn-nbn self-link to Sword Statement

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -142,6 +142,11 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
       .map(_.toString)
   }
 
+  def getUrn: Option[String] = {
+    Option(properties.getProperty("identifier.urn"))
+      .map(_.toString)
+  }
+
   /**
    * Returns the last modified timestamp when the properties were loaded.
    *

--- a/src/main/scala/nl.knaw.dans.easy.sword2/StatementManagerImpl.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/StatementManagerImpl.scala
@@ -59,6 +59,7 @@ class StatementManagerImpl extends StatementManager with DebugEnhancedLogging {
       stateDesc <- props.getStateDescription
       _ = debug(s"State desc = $stateDesc")
       optDoi = props.getDoi
+      optUrn = props.getUrn
     } yield new AtomStatement(statementIri, "DANS-EASY", s"Deposit $id", props.getLastModifiedTimestamp.get.toString) {
       addState(state.toString, stateDesc)
       val archivalResource = new ResourcePart(new URI(s"urn:uuid:$id").toASCIIString)
@@ -66,6 +67,9 @@ class StatementManagerImpl extends StatementManager with DebugEnhancedLogging {
 
       optDoi.foreach(doi => {
         archivalResource.addSelfLink(new URI(s"https://doi.org/$doi").toASCIIString)
+      })
+      optUrn.foreach(urn => {
+        archivalResource.addSelfLink(new URI(s"http://www.persistent-identifier.nl?identifier=$urn").toASCIIString)
       })
 
       addResource(archivalResource)


### PR DESCRIPTION
Fixes EASY-2739

#### When applied it will
* Add urn-nbn self-link to Sword Statement

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Submit a deposit, retrieve the sword-statement. 
It has two self-links, one to the DOI, one to the URN:NBN
