### PR TITLE
DD-404 - Extensions to easy-sword2 to make it work with dd-dans-deposit-to-dataverse

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -2,6 +2,7 @@ daemon.http.port=20100
 deposits.rootdir=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox
 deposits.archived-rootdir=/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox-archived
 deposits.permissions=rwxrwx---
+deposits.outbox=
 tempdir=/var/opt/dans.knaw.nl/tmp/easy-sword2
 # Require at least some 2 G  spare disk space
 tempdir.margin-available-diskspace=2000000000

--- a/src/main/scala/nl.knaw.dans.easy.sword2/Configuration.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/Configuration.scala
@@ -35,6 +35,7 @@ case class Configuration(version: String, properties: PropertiesConfiguration) {
   val settings: Settings = Settings(
     depositRootDir = new File(properties.getString("deposits.rootdir")),
     archivedDepositRootDir = properties.getString("deposits.archived-rootdir").toOption.map(new File(_)).filter(d => d.exists && d.canRead),
+    outboxDir = properties.getString("deposits.outbox").toOption.map(new File(_)).filter(d => d.exists() && d.canRead),
     depositPermissions = properties.getString("deposits.permissions"),
     tempDir = new File(properties.getString("tempdir")),
     serviceBaseUrl = properties.getString("base-url"),

--- a/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/package.scala
@@ -34,6 +34,7 @@ package object sword2 {
 
   case class Settings(depositRootDir: File,
                       archivedDepositRootDir: Option[File],
+                      outboxDir: Option[File],
                       depositPermissions: String,
                       tempDir: File,
                       serviceBaseUrl: String, // TODO: refactor to URL?

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -2,6 +2,7 @@ daemon.http.port=20100
 deposits.rootdir=data/deposits
 deposits.archived-rootdir=data/deposits-archived
 deposits.permissions=rwxrwx---
+deposits.outbox=
 tempdir=data/temp
 # Require at least some 2 G  spare disk space
 tempdir.margin-available-diskspace=2000000000

--- a/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/AuthenticationSpec.scala
@@ -36,6 +36,7 @@ class AuthenticationSpec extends AnyFlatSpec with Matchers with MockFactory with
   implicit val settings: Settings = Settings(
     depositRootDir = new File("dummy"),
     archivedDepositRootDir = Option(new File("dummy")),
+    outboxDir = None,
     depositPermissions = "dummy",
     tempDir = new File("dummy"),
     serviceBaseUrl = "dummy",

--- a/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.sword2/TestSupportFixture.scala
@@ -36,6 +36,7 @@ trait TestSupportFixture extends AnyFlatSpec with Matchers with OptionValues {
     new SwordConfig {
       settings = Settings(depositRootDir = bag.toJava,
         archivedDepositRootDir = Option.empty,
+        outboxDir = Option.empty,
         "rwxrwxrwx",
         new java.io.File("dummy"),
         "",


### PR DESCRIPTION
Fixes DD-404

Note: see the discussion in: https://drivenbydata.atlassian.net/browse/DD-404

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
