### PR TITLE
DD-563: Implement rule 1.2.7 (Organizational-Id) of the Dans Bagit Profile in easy-sword2

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
+++ b/src/main/scala/nl.knaw.dans.easy.sword2/DepositProperties.scala
@@ -103,6 +103,11 @@ class DepositProperties(depositId: DepositId, depositorId: Option[String] = None
     this
   }
 
+  def setOtherIdentifier(id: String, version: String): Try[DepositProperties] = Try {
+    if (id.nonEmpty) properties.setProperty("dataverse.other-id", id)
+    if (version.nonEmpty) properties.setProperty("dataverse.other-id-version", version)
+    this
+  }
 
   /**
    * Returns the state when the properties were loaded.


### PR DESCRIPTION
Fixes DD-563

#### When applied it will
* write `dataverse.other-id` to properties if `Has-Organizational-Identifier` is given in bag-info.txt
* write `dataverse.other-id-version` to properties if `Has-Organizational-Identifier-Version` is given in bag-info.txt

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     | ..
